### PR TITLE
[Client] Workspace common의 이름을 shared로 변경

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,13 +10,14 @@
     "test": "jest"
   },
   "dependencies": {
+    "@mui/icons-material": "^5.10.9",
     "@tanstack/react-query": "^4.16.1",
     "axios": "^1.1.3",
     "classnames": "^2.3.2",
-    "shared": "1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
+    "shared": "1.0.0",
     "tailwindcss": "^3.2.4",
     "zustand": "^4.1.4"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "test:e2e": "jest --config ./apps/server/test/jest-e2e.json"
   },
   "dependencies": {
-    "common" : "1.0.0",
+    "shared" : "1.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,7 +1027,7 @@
     "@babel/helper-validator-option" "^7.18.6"
     "@babel/plugin-transform-typescript" "^7.18.6"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.19.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
   integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
@@ -1621,6 +1621,13 @@
     outvariant "^1.2.1"
     strict-event-emitter "^0.2.4"
     web-encoding "^1.1.5"
+
+"@mui/icons-material@^5.10.9":
+  version "5.10.9"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.10.9.tgz#f9522c49797caf30146acc576e37ecb4f95bbc38"
+  integrity sha512-sqClXdEM39WKQJOQ0ZCPTptaZgqwibhj2EFV9N0v7BU1PO8y4OcX/a2wIQHn4fNuDjIZktJIBrmU23h7aqlGgg==
+  dependencies:
+    "@babel/runtime" "^7.19.0"
 
 "@nestjs/cli@^9.0.0":
   version "9.1.5"


### PR DESCRIPTION
## 🤷‍♂️ Description

- common 워크스페이스 이름을 shared로 수정 
- 기존의 common이 남아있으면 실제 존재하는 common 라이브러리로 인식하기 때문에 문제 발생할 수 있어서 급하게 수정합니다.


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] server의 common 라이브러리 이름을 shared로 바꿈
- [x] mui/icons-material 라이브러리 추가

 
## 📒 Remarks

- 백엔드 브랜치 머지할 때 충돌 날 것임.


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
