### PR TITLE
[Server/auth] accessToken 재발행 로직 구현, 로그아웃 로직 구현

### DIFF
--- a/server/apps/api/src/auth/auth.controller.ts
+++ b/server/apps/api/src/auth/auth.controller.ts
@@ -4,7 +4,7 @@ import { SignInDto, SignUpDto } from './dto';
 import { responseForm } from '@utils/responseForm';
 import { Response } from 'express';
 import { getUserBasicInfo } from '@user/dto/user-basic-info.dto';
-import { JwtAuthGuard } from '@api/src/auth/guard';
+import { JwtAccessGuard } from '@api/src/auth/guard';
 
 @Controller('api/user/auth')
 export class AuthController {
@@ -32,7 +32,7 @@ export class AuthController {
   }
 
   @Get('me')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAccessGuard)
   async getMyInfo(@Req() req: any) {
     return getUserBasicInfo(req.user);
   }

--- a/server/apps/api/src/auth/auth.controller.ts
+++ b/server/apps/api/src/auth/auth.controller.ts
@@ -49,8 +49,9 @@ export class AuthController {
 
   @Post('signout')
   @UseGuards(JwtAccessGuard)
-  async singOut(@Req() req: any) {
-    await this.authService.signOut(req.user._id);
+  async singOut(@Req() req: any, @Res({ passthrough: true }) res: Response) {
+    await this.authService.signOut(req.user._id); // DB에서 refreshToken 제거
+    res.cookie('refreshToken', 'expired', { maxAge: -1 }); // client에서 refreshToken 제거
     return responseForm(200, { message: '로그아웃 성공!' });
   }
 }

--- a/server/apps/api/src/auth/auth.controller.ts
+++ b/server/apps/api/src/auth/auth.controller.ts
@@ -10,13 +10,13 @@ import { JwtAccessGuard, JwtRefreshGuard } from '@api/src/auth/guard';
 export class AuthController {
   constructor(private authService: AuthService) {}
 
-  @Post('signup')
+  @Post('signup') // 회원가입
   async signUp(@Body() signUpDto: SignUpDto) {
     await this.authService.signUp(signUpDto);
     return responseForm(200, { message: '회원가입 성공!' });
   }
 
-  @Post('signin')
+  @Post('signin') // 로그인
   async signIn(@Body() signInDto: SignInDto, @Res({ passthrough: true }) res: Response) {
     const { refreshToken, accessToken } = await this.authService.signIn(signInDto);
 
@@ -31,7 +31,7 @@ export class AuthController {
     return responseForm(200, { message: '로그인 성공!', accessToken });
   }
 
-  @Post('refresh')
+  @Post('refresh') // AccessToken 재발행
   @UseGuards(JwtRefreshGuard)
   async refresh(@Req() req: any) {
     const accessToken = req.user;
@@ -41,9 +41,16 @@ export class AuthController {
     return responseForm(200, { message: 'accessToken 재발행 성공!', accessToken });
   }
 
-  @Get('me')
+  @Get('me') // 자신의 유저 정보 제공
   @UseGuards(JwtAccessGuard)
   async getMyInfo(@Req() req: any) {
     return getUserBasicInfo(req.user);
+  }
+
+  @Post('signout')
+  @UseGuards(JwtAccessGuard)
+  async singOut(@Req() req: any) {
+    await this.authService.signOut(req.user._id);
+    return responseForm(200, { message: '로그아웃 성공!' });
   }
 }

--- a/server/apps/api/src/auth/auth.module.ts
+++ b/server/apps/api/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { User, UserSchema } from '@schemas/user.schema';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtAccessStrategy, JwtRefreshStrategy } from '@api/src/auth/strategy';
+import { SignToken } from '@api/src/auth/helper/signToken';
 
 @Module({
   imports: [
@@ -15,6 +16,6 @@ import { JwtAccessStrategy, JwtRefreshStrategy } from '@api/src/auth/strategy';
     JwtModule.register({}),
   ],
   controllers: [AuthController],
-  providers: [AuthService, UserRepository, JwtAccessStrategy, JwtRefreshStrategy],
+  providers: [AuthService, UserRepository, JwtAccessStrategy, JwtRefreshStrategy, SignToken],
 })
 export class AuthModule {}

--- a/server/apps/api/src/auth/auth.module.ts
+++ b/server/apps/api/src/auth/auth.module.ts
@@ -6,7 +6,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from '@schemas/user.schema';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
-import { JwtStrategy } from '@api/src/auth/strategy';
+import { JwtAccessStrategy } from '@api/src/auth/strategy';
 
 @Module({
   imports: [
@@ -15,6 +15,6 @@ import { JwtStrategy } from '@api/src/auth/strategy';
     JwtModule.register({}),
   ],
   controllers: [AuthController],
-  providers: [AuthService, UserRepository, JwtStrategy],
+  providers: [AuthService, UserRepository, JwtAccessStrategy],
 })
 export class AuthModule {}

--- a/server/apps/api/src/auth/auth.module.ts
+++ b/server/apps/api/src/auth/auth.module.ts
@@ -6,7 +6,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from '@schemas/user.schema';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
-import { JwtAccessStrategy } from '@api/src/auth/strategy';
+import { JwtAccessStrategy, JwtRefreshStrategy } from '@api/src/auth/strategy';
 
 @Module({
   imports: [
@@ -15,6 +15,6 @@ import { JwtAccessStrategy } from '@api/src/auth/strategy';
     JwtModule.register({}),
   ],
   controllers: [AuthController],
-  providers: [AuthService, UserRepository, JwtAccessStrategy],
+  providers: [AuthService, UserRepository, JwtAccessStrategy, JwtRefreshStrategy],
 })
 export class AuthModule {}

--- a/server/apps/api/src/auth/auth.service.ts
+++ b/server/apps/api/src/auth/auth.service.ts
@@ -44,7 +44,6 @@ export class AuthService {
 
   async signOut(userId: string) {
     try {
-      console.log(userId);
       await this.userRepository.updateOne({ _id: userId }, { refreshToken: '' });
     } catch (error) {
       throw new ForbiddenException('잘못된 접근입니다.');

--- a/server/apps/api/src/auth/auth.service.ts
+++ b/server/apps/api/src/auth/auth.service.ts
@@ -38,7 +38,8 @@ export class AuthService {
       throw new ForbiddenException('비밀번호가 일치하지 않습니다.');
     }
     // accessToken, refreshToken 발행
-    const { accessToken, refreshToken } = await this.signToken(user._id, user.nickname);
+    const accessToken = await this.signAccessToken(user._id, user.nickname);
+    const refreshToken = await this.signRefreshToken(user._id);
 
     // DB에 refreshToken 업데이트
     this.userRepository.updateOne({ _id: user._id }, { refreshToken });
@@ -46,29 +47,26 @@ export class AuthService {
     return { accessToken, refreshToken };
   }
 
-  async signToken(
-    _id: number,
-    nickname: string,
-  ): Promise<{ accessToken: string; refreshToken: string }> {
+  async signAccessToken(_id: number, nickname: string): Promise<string> {
     const accessTokenPayload = {
       _id,
       nickname,
     };
-
-    const refreshTokenPayload = {
-      _id,
-    };
-
     const accessToken = await this.jwt.signAsync(accessTokenPayload, {
       expiresIn: '15m',
       secret: this.config.get('JWT_SECRET'),
     });
+    return accessToken;
+  }
 
+  async signRefreshToken(_id: number): Promise<string> {
+    const refreshTokenPayload = {
+      _id,
+    };
     const refreshToken = await this.jwt.signAsync(refreshTokenPayload, {
-      expiresIn: '1hr',
+      expiresIn: '100hr',
       secret: this.config.get('JWT_SECRET'),
     });
-
-    return { accessToken, refreshToken };
+    return refreshToken;
   }
 }

--- a/server/apps/api/src/auth/guard/index.ts
+++ b/server/apps/api/src/auth/guard/index.ts
@@ -1,1 +1,2 @@
 export * from './jwt-access.guard';
+export * from './jwt-refresh.guard';

--- a/server/apps/api/src/auth/guard/index.ts
+++ b/server/apps/api/src/auth/guard/index.ts
@@ -1,1 +1,1 @@
-export * from './auth.guard';
+export * from './jwt-access.guard';

--- a/server/apps/api/src/auth/guard/jwt-access.guard.ts
+++ b/server/apps/api/src/auth/guard/jwt-access.guard.ts
@@ -2,4 +2,4 @@ import { AuthGuard } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class JwtAccessGuard extends AuthGuard('jwt') {}
+export class JwtAccessGuard extends AuthGuard('jwt-access-token') {}

--- a/server/apps/api/src/auth/guard/jwt-access.guard.ts
+++ b/server/apps/api/src/auth/guard/jwt-access.guard.ts
@@ -2,4 +2,4 @@ import { AuthGuard } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAccessGuard extends AuthGuard('jwt') {}

--- a/server/apps/api/src/auth/guard/jwt-refresh.guard.ts
+++ b/server/apps/api/src/auth/guard/jwt-refresh.guard.ts
@@ -1,0 +1,5 @@
+import { AuthGuard } from '@nestjs/passport';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class JwtRefreshGuard extends AuthGuard('jwt-refresh-token') {}

--- a/server/apps/api/src/auth/helper/signToken.ts
+++ b/server/apps/api/src/auth/helper/signToken.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class SignToken {
+  constructor(private jwt: JwtService, private config: ConfigService) {}
+  async signAccessToken(_id: number, nickname: string): Promise<string> {
+    const accessTokenPayload = {
+      _id,
+      nickname,
+    };
+    const accessToken = await this.jwt.signAsync(accessTokenPayload, {
+      expiresIn: '15m',
+      secret: this.config.get('JWT_SECRET'),
+    });
+    return accessToken;
+  }
+
+  async signRefreshToken(_id: number): Promise<string> {
+    const refreshTokenPayload = {
+      _id,
+    };
+    const refreshToken = await this.jwt.signAsync(refreshTokenPayload, {
+      expiresIn: '100hr',
+      secret: this.config.get('JWT_SECRET'),
+    });
+    return refreshToken;
+  }
+}

--- a/server/apps/api/src/auth/strategy/index.ts
+++ b/server/apps/api/src/auth/strategy/index.ts
@@ -1,1 +1,2 @@
 export * from './jwt-access.strategy';
+export * from './jwt-refresh.strategy';

--- a/server/apps/api/src/auth/strategy/index.ts
+++ b/server/apps/api/src/auth/strategy/index.ts
@@ -1,1 +1,1 @@
-export * from './auth.strategy';
+export * from './jwt-access.strategy';

--- a/server/apps/api/src/auth/strategy/jwt-access.strategy.ts
+++ b/server/apps/api/src/auth/strategy/jwt-access.strategy.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { ForbiddenException, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class JwtAccessStrategy extends PassportStrategy(Strategy, 'jwt') {
+export class JwtAccessStrategy extends PassportStrategy(Strategy, 'jwt-access-token') {
   constructor(config: ConfigService, private userRepository: UserRepository) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),

--- a/server/apps/api/src/auth/strategy/jwt-access.strategy.ts
+++ b/server/apps/api/src/auth/strategy/jwt-access.strategy.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { ForbiddenException, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+export class JwtAccessStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(config: ConfigService, private userRepository: UserRepository) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),

--- a/server/apps/api/src/auth/strategy/jwt-refresh.strategy.ts
+++ b/server/apps/api/src/auth/strategy/jwt-refresh.strategy.ts
@@ -3,14 +3,14 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 import { UserRepository } from '@repository/user.repository';
-import { AuthService } from '@api/src/auth/auth.service';
+import { SignToken } from '@api/src/auth/helper/signToken';
 
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh-token') {
   constructor(
     config: ConfigService,
     private userRepository: UserRepository,
-    private authService: AuthService,
+    private signToken: SignToken,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
@@ -34,7 +34,7 @@ export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh-
       throw new UnauthorizedException('refreshToken이 일치하지 않습니다.');
     }
 
-    const accessToken = await this.authService.signAccessToken(user._id, user.nickname);
+    const accessToken = await this.signToken.signAccessToken(user._id, user.nickname);
 
     return accessToken;
   }

--- a/server/apps/api/src/auth/strategy/jwt-refresh.strategy.ts
+++ b/server/apps/api/src/auth/strategy/jwt-refresh.strategy.ts
@@ -1,0 +1,39 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+import { UserRepository } from '@repository/user.repository';
+
+@Injectable()
+export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh-token') {
+  constructor(config: ConfigService, private userRepository: UserRepository) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request) => {
+          return request?.cookies?.refreshToken;
+        },
+      ]),
+      secretOrKey: config.get('JWT_SECRET'),
+      passReqToCallback: true,
+    });
+  }
+
+  async validate(req, payload: any) {
+    console.log(payload);
+    const refreshToken = req.cookies?.refreshToken;
+    const user = await this.userRepository.findById(payload._id);
+    if (!user) {
+      throw new ForbiddenException('잘못된 요청입니다.');
+    }
+    if (refreshToken !== user.refreshToken) {
+      console.log('refreshToken : ', refreshToken);
+      console.log('user.refreshToken : ', user.refreshToken);
+      return false;
+    }
+
+    // TODO: accessToken 재발행 로직
+
+    console.log('accessToken 재발행 필요');
+    return 'accessToken';
+  }
+}

--- a/server/apps/api/src/main.ts
+++ b/server/apps/api/src/main.ts
@@ -4,6 +4,7 @@ import { ApiModule } from './api.module';
 import { ValidationPipe } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import { SentryInterceptor } from '../../webhook.interceptor';
+import * as cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(ApiModule);
@@ -14,6 +15,7 @@ async function bootstrap() {
     });
     app.useGlobalInterceptors(new SentryInterceptor());
   }
+  app.use(cookieParser());
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
   app.useGlobalPipes(new ValidationPipe());
   await app.listen(3000);

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "@sentry/node": "^7.20.0",
     "@slack/client": "^5.0.2",
     "@slack/webhook": "^6.1.0",
+    "@types/cookie-parser": "^1.4.3",
     "@types/express": "^4.17.13",
     "@types/jest": "28.1.8",
     "@types/node": "^16.0.0",


### PR DESCRIPTION
## Issues

- #11 
- #17 

## 🤷‍♂️ Description

refreshToken을 통해 accessToken을 재발행 하는 로직 구현
로그아웃시, user DB에서 refreshToken 제거

## 📝 Primary Commits

- cookie에 저장된 refreshToken을 사용하기 위한 cookieParser 미들웨어 적용
- refreshToken검증을 위한 Guard, Strategy 생성
- DB에 저장된 refreshToken과 쿠키에 있는 refreshToken이 일치하는지 확인
- 일치하면 accessToken 재발행


## 📷 Screenshots

- 유효한 refreshToken
  <img width="720" alt="1" src="https://user-images.githubusercontent.com/72093196/203003478-f78dc797-eb92-4a32-ae94-2e9c97c94217.png">

    - 유효한 refreshToken 하지만 DB에 저장된 refreshToken과 일치하지 않음
        
       <img width="406" alt="2" src="https://user-images.githubusercontent.com/72093196/203003507-ae84b06f-b67c-4253-8ee6-f8c1cd1b6225.png">
     - 유효한 refreshToken 하지만 user정보가 DB에 없음
         <img width="428" alt="3" src="https://user-images.githubusercontent.com/72093196/203003625-9bdbe152-9a3b-4e0d-82d4-e5380ee77184.png">

            
- 유효하지 않은 refreshToken
  <img width="505" alt="4" src="https://user-images.githubusercontent.com/72093196/203003637-b74b27ec-5fca-4016-8116-0a3e4e545e2a.png">

 
## 📒 Remarks

refreshToken 만료시간이 기존에 1시간 이었는데, 너무 작아서 100시간으로 수정했습니다!
