### PR TITLE
[CLIENT] 회원가입 페이지 리팩토링

### DIFF
--- a/client/src/apis/auth.ts
+++ b/client/src/apis/auth.ts
@@ -1,0 +1,23 @@
+import { SuccessResponse } from '@@types/apis/response';
+import { API_URL } from '@constants/url';
+import axios from 'axios';
+
+export interface SignUpRequest {
+  id: string;
+  nickname: string;
+  password: string;
+}
+
+export interface SignUpResult {
+  message: string;
+}
+
+type SignUp = (fields: SignUpRequest) => Promise<SuccessResponse<SignUpResult>>;
+
+export const signUp: SignUp = ({ id, nickname, password }) => {
+  const endPoint = `${API_URL}/api/user/auth/signup`;
+
+  return axios
+    .post(endPoint, { id, nickname, password })
+    .then((response) => response.data);
+};

--- a/client/src/constants/regex.ts
+++ b/client/src/constants/regex.ts
@@ -1,0 +1,5 @@
+const REGEX = {
+  EMAIL: new RegExp('^\\w+([.-]?\\w+)*@\\w+([.-]?\\w+)*(\\.\\w{2,3})+$'),
+};
+
+export default REGEX;

--- a/client/src/errors/defaultErrorHandler.ts
+++ b/client/src/errors/defaultErrorHandler.ts
@@ -1,0 +1,23 @@
+import { AxiosError } from 'axios';
+import { toast } from 'react-toastify';
+
+const defaultErrorHandler = (error: unknown) => {
+  if (error instanceof AxiosError) {
+    const errorMessage =
+      error?.response?.data?.message || '에러가 발생했습니다!';
+
+    if (Array.isArray(errorMessage)) {
+      errorMessage.forEach((message) => {
+        toast.error(message);
+      });
+      return;
+    }
+
+    toast.error(errorMessage);
+    return;
+  }
+
+  toast.error('Unknown Error');
+};
+
+export default defaultErrorHandler;

--- a/client/src/hooks/useSignUpMutation.ts
+++ b/client/src/hooks/useSignUpMutation.ts
@@ -1,0 +1,25 @@
+import type { SuccessResponse } from '@@types/apis/response';
+import type { SignUpRequest, SignUpResult } from '@apis/auth';
+import type { UseMutationOptions } from '@tanstack/react-query';
+
+import { signUp } from '@apis/auth';
+import { useMutation } from '@tanstack/react-query';
+
+import queryKeyCreator from '@/queryKeyCreator';
+
+const useSignUpMutation = (
+  options: UseMutationOptions<
+    SuccessResponse<SignUpResult>,
+    unknown,
+    SignUpRequest
+  >,
+) => {
+  const key = queryKeyCreator.signUp();
+  const mutation = useMutation(key, signUp, {
+    ...options,
+  });
+
+  return mutation;
+};
+
+export default useSignUpMutation;

--- a/client/src/pages/SignUp/index.tsx
+++ b/client/src/pages/SignUp/index.tsx
@@ -18,34 +18,20 @@ interface SignUpFormFields extends SignUpRequest {
   passwordCheck: string;
 }
 
-interface SuccessResponse<T> {
-  statusCode: number;
-  result: T;
-}
-
-type SignUpApi = (
-  fields: Omit<SignUpFields, 'passwordCheck'>,
-) => Promise<SuccessResponse<{ message: string }>>;
-
-const endPoint = `${API_URL}/api/user/auth/signup`;
-
-const signUpApi: SignUpApi = ({ id, nickname, password }) => {
-  return axios
-    .post(endPoint, { id, nickname, password })
-    .then((response) => response.data);
+const signUpFormDefaultValues = {
+  id: '',
+  nickname: '',
+  password: '',
+  passwordCheck: '',
 };
 
 const SignUp = () => {
-  // TODO: 리팩토링 하자
-  const { control, handleSubmit, watch, reset } = useForm<SignUpFields>({
+  const { control, handleSubmit, watch, reset } = useForm<SignUpFormFields>({
     mode: 'all',
-    defaultValues: {
-      id: '',
-      nickname: '',
-      password: '',
-      passwordCheck: '',
-    },
+    defaultValues: signUpFormDefaultValues,
   });
+
+  const password = watch('password');
 
   const navigate = useNavigate();
 
@@ -55,22 +41,7 @@ const SignUp = () => {
       reset();
     },
     onError: (error) => {
-      if (error instanceof AxiosError) {
-        const errorMessage =
-          error?.response?.data?.message || '에러가 발생했습니다!';
-
-        if (Array.isArray(errorMessage)) {
-          errorMessage.forEach((message) => {
-            toast.error(message);
-          });
-          return;
-        }
-
-        toast.error(errorMessage);
-        return;
-      }
-
-      toast.error('Unknown Error');
+      defaultErrorHandler(error);
     },
   });
 

--- a/client/src/pages/SignUp/index.tsx
+++ b/client/src/pages/SignUp/index.tsx
@@ -98,7 +98,7 @@ const SignUp = () => {
           control={control}
           rules={{
             pattern: {
-              value: /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/,
+              value: REGEX.EMAIL,
               message: '아이디는 이메일 형식으로 입력해야 합니다!',
             },
             required: '필수 요소입니다!',

--- a/client/src/pages/SignUp/index.tsx
+++ b/client/src/pages/SignUp/index.tsx
@@ -6,9 +6,9 @@ import ErrorMessage from '@components/ErrorMessage';
 import Logo from '@components/Logo';
 import SuccessMessage from '@components/SuccessMessage';
 import TextButton from '@components/TextButton';
-import { API_URL } from '@constants/url';
-import { useMutation } from '@tanstack/react-query';
-import axios, { AxiosError } from 'axios';
+import REGEX from '@constants/regex';
+import defaultErrorHandler from '@errors/defaultErrorHandler';
+import useSignUpMutation from '@hooks/useSignUpMutation';
 import React from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -49,7 +49,7 @@ const SignUp = () => {
 
   const navigate = useNavigate();
 
-  const signUpMutate = useMutation(['signUp'], signUpApi, {
+  const signUpMutation = useSignUpMutation({
     onSuccess: () => {
       toast.success('회원가입에 성공했습니다.');
       reset();
@@ -74,10 +74,8 @@ const SignUp = () => {
     },
   });
 
-  const password = watch('password');
-
-  const handleSubmitSignUpForm = (fields: SignUpFields) => {
-    signUpMutate.mutate(fields);
+  const handleSubmitSignUpForm = (fields: SignUpFormFields) => {
+    signUpMutation.mutate(fields);
   };
 
   const handleNavigateSignInPage = () => {
@@ -219,7 +217,7 @@ const SignUp = () => {
             size="md"
             type="submit"
             minWidth={340}
-            disabled={signUpMutate.isLoading}
+            disabled={signUpMutation.isLoading}
           >
             회원가입
           </Button>

--- a/client/src/pages/SignUp/index.tsx
+++ b/client/src/pages/SignUp/index.tsx
@@ -1,3 +1,5 @@
+import type { SignUpRequest } from '@apis/auth';
+
 import AuthInput from '@components/AuthInput';
 import Button from '@components/Button';
 import ErrorMessage from '@components/ErrorMessage';
@@ -12,10 +14,7 @@ import { useForm, Controller } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
-interface SignUpFields {
-  id: string;
-  nickname: string;
-  password: string;
+interface SignUpFormFields extends SignUpRequest {
   passwordCheck: string;
 }
 

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -1,5 +1,6 @@
 const queryKeyCreator = {
   me: () => ['me'],
+  signUp: () => ['signUp'],
 } as const;
 
 export default queryKeyCreator;

--- a/client/src/types/apis/response.ts
+++ b/client/src/types/apis/response.ts
@@ -1,0 +1,10 @@
+export interface SuccessResponse<T> {
+  statusCode: number;
+  result: T;
+}
+
+export interface ErrorResponse {
+  statusCode: number;
+  message: string | string[];
+  error: string;
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,6 +6,7 @@
     "baseUrl": ".",
     "outDir": "./build",
     "paths": {
+      "@/*": ["src/*"],
       "@pages/*": ["src/pages/*"],
       "@layouts/*": ["src/layouts/*"],
       "@components/*": ["src/components/*"],
@@ -14,6 +15,9 @@
       "@icons/*": ["src/assets/icons/*"],
       "@constants/*": ["src/constants/*"],
       "@apis/*": ["src/apis/*"],
+      "@hooks/*": ["src/hooks/*"],
+      "@errors/*": ["src/errors/*"],
+      "@@types/*": ["src/types/*"],
     }
   },
   "include": ["src", "config"],


### PR DESCRIPTION
## Issues
- #84 

<!-- 어떤 이슈와 관련된 PR인지 적어주세요! 이슈와 PR을 연결하려면 반드시 적어야 합니다. -->
<!-- 필요하다면 여러 이슈를 적는 것도 가능할지도? -->
<!-- - #IssueNumber 로 타이핑하면 자동완성되는 문장을 사용해주세요. -->
<!-- 예시) - #1 -->

## 🤷‍♂️ Description

- 회원가입 페이지 리팩토링 관련 PR

## 📝 Primary Commits
 
- [X] 회원가입 apis 분리 (apis 디렉토리 생성)
- [X] React-query의 뮤테이션을 커스텀 훅으로 분리
- [X] REGEX 상수 객체 추가 (현재는 EMAIL REGEX를 추가)
- [X] `defaultErrorHandler`정의
- [X] Response Type 정의
- [X] path alias 업데이트

## 📒 Remarks

<!-- 추가로 전달하거나 메모해 둘 내용이 있다면 적어주세요!  -->
<!-- 따로 메모해 둘 내용이 없다면 Remarks 블럭은 지워주세요 -->


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
