### PR TITLE
[Server/channel-modify] 채널 정보 수정 API

### DIFF
--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -1,7 +1,16 @@
-import { Body, Controller, Inject, LoggerService, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Inject,
+  LoggerService,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
 import { ChannelService } from '@api/src/channel/channel.service';
 import { JwtAccessGuard } from '@api/src/auth/guard';
-import { CreateChannelDto } from '@api/src/channel/dto';
+import { CreateChannelDto, ModifyChannelDto } from '@api/src/channel/dto';
 import { responseForm } from '@utils/responseForm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
@@ -19,6 +28,19 @@ export class ChannelController {
     try {
       await this.channelService.createChannel({ ...createChannelDto, managerId: _id });
       return responseForm(200, { message: '채널 생성 성공!' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+
+  @Patch('settings')
+  @UseGuards(JwtAccessGuard)
+  async modifyChannel(@Body() modifyChannelDto: ModifyChannelDto, @Req() req: any) {
+    const _id = req.user._id;
+    try {
+      this.channelService.modifyChannel({ ...modifyChannelDto, managerId: _id });
+      return responseForm(200, { message: '채널 수정 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
       throw error;

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -39,7 +39,7 @@ export class ChannelController {
   async modifyChannel(@Body() modifyChannelDto: ModifyChannelDto, @Req() req: any) {
     const _id = req.user._id;
     try {
-      this.channelService.modifyChannel({ ...modifyChannelDto, managerId: _id });
+      await this.channelService.modifyChannel({ ...modifyChannelDto, managerId: _id });
       return responseForm(200, { message: '채널 수정 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { ChannelRepository } from '@repository/channel.repository';
-import { CreateChannelDto } from '@api/src/channel/dto';
+import { CreateChannelDto, ModifyChannelDto } from '@api/src/channel/dto';
 import { CommunityRepository } from '@repository/community.repository';
 import { UserRepository } from '@repository/user.repository';
 import { addChannelToUserForm } from '@utils/addObjectForm';
@@ -34,6 +34,14 @@ export class ChannelService {
       await this.userRepository.updateObject({ _id: createChannelDto.managerId }, newChannel);
     } catch (error) {
       throw new BadRequestException('채널 생성 중 오류 발생!');
+    }
+  }
+
+  async modifyChannel(modifyChannelDto: ModifyChannelDto) {
+    try {
+      await this.channelRepository.updateOne({ id: modifyChannelDto.channelId }, modifyChannelDto);
+    } catch (error) {
+      throw new BadRequestException('채널 수정 중 오류 발생!');
     }
   }
 }

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ChannelRepository } from '@repository/channel.repository';
 import { CreateChannelDto, ModifyChannelDto } from '@api/src/channel/dto';
 import { CommunityRepository } from '@repository/community.repository';
@@ -38,6 +38,13 @@ export class ChannelService {
   }
 
   async modifyChannel(modifyChannelDto: ModifyChannelDto) {
+    // 채널의 관리자가 아니면 예외처리
+    const channel = await this.channelRepository.findOne({ id: modifyChannelDto.channelId });
+    if (channel === undefined || modifyChannelDto.managerId !== channel.managerId) {
+      throw new UnauthorizedException('채널 관리자가 아닙니다.');
+    }
+
+    // 채널 수정
     try {
       await this.channelRepository.updateOne({ id: modifyChannelDto.channelId }, modifyChannelDto);
     } catch (error) {

--- a/server/apps/api/src/channel/dto/index.ts
+++ b/server/apps/api/src/channel/dto/index.ts
@@ -1,1 +1,2 @@
 export * from './create-channel.dto';
+export * from './modify-channel.dto';

--- a/server/apps/api/src/channel/dto/modify-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/modify-channel.dto.ts
@@ -1,0 +1,25 @@
+import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class ModifyChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  channelId: string;
+
+  @IsString()
+  @IsOptional()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  managerId: string;
+
+  @IsString()
+  @IsOptional()
+  description: string;
+
+  @IsBoolean()
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  isPrivate: boolean;
+}

--- a/server/dao/repository/channel.repository.ts
+++ b/server/dao/repository/channel.repository.ts
@@ -15,4 +15,8 @@ export class ChannelRepository {
   async findOne(condition: any) {
     return await this.channelModel.findOne(condition);
   }
+
+  async updateOne(filter, updateField) {
+    return await this.channelModel.updateOne(filter, updateField);
+  }
 }


### PR DESCRIPTION
## Issues
- #113 

## 🤷‍♂️ Description

채널 정보 수정

## 📝 Primary Commits

- [x]  채널 수정을 위한 dto 작성
    
    ```
    channel_id: String, NotEmpty
    managerId: String, Optional
    description: String, Optional
    profileUrl: String, Optional
    isPrivate: Boolean, Optional
    ```
    
- [x]  channel.repository
    - 채널 업데이트 할 수 있는 함수 생성
    - `findById`
    - `updateOne`
- [x]  channel.controller
    - `POST /api/channel/setting`
    - `UseGuards(JwtAccessGuard)`
- [x]  channel.service
    - channel_id에 해당하는 channel정보 가져옴
    - 가져온 channel의 managerId와 인자로 받은 api요청을 보낸 유저 id비교
    - 맞으면 업데이트 해줌
- [x]  에러 처리

## 📷 Screenshots

- 성공
  <img width="433" alt="스크린샷 2022-11-26 오전 12 03 13" src="https://user-images.githubusercontent.com/72093196/204011856-cf0aebec-eb09-49d9-85ec-3be8eea3f1b4.png">

- 에러
  - 채널 수정하는 사용자가 채널 관리자가 아닐 경우
    <img width="464" alt="스크린샷 2022-11-26 오전 12 04 06" src="https://user-images.githubusercontent.com/72093196/204012011-d39fc0c8-9322-4b88-aac0-774de523ec96.png">
