### PR TITLE
[Server/Feature] 현재 사용자가 속한 커뮤니티 및 채널들의 기본 정보 전달

### DIFF
--- a/server/apps/api/src/channel/channel.module.ts
+++ b/server/apps/api/src/channel/channel.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { ChannelController } from './channel.controller';
 import { ChannelService } from './channel.service';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -13,10 +13,11 @@ import { UserModule } from '@user/user.module';
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Channel.name, schema: ChannelSchema }]),
-    CommunityModule,
+    forwardRef(() => CommunityModule),
     UserModule,
   ],
   controllers: [ChannelController],
   providers: [ChannelService, ChannelRepository, CommunityRepository, UserRepository],
+  exports: [MongooseModule],
 })
 export class ChannelModule {}

--- a/server/apps/api/src/channel/dto/channel-basic-info.dto.ts
+++ b/server/apps/api/src/channel/dto/channel-basic-info.dto.ts
@@ -1,0 +1,11 @@
+export const getChannelBasicInfo = (channel) => {
+  return {
+    _id: channel._id,
+    name: channel.name,
+    managerId: channel.managerId,
+    type: channel.type,
+    isPrivate: channel.isPrivate,
+    profileUrl: channel.profileUrl,
+    description: channel.description,
+  };
+};

--- a/server/apps/api/src/community/community.module.ts
+++ b/server/apps/api/src/community/community.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { CommunityController } from './community.controller';
 import { CommunityService } from './community.service';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -6,14 +6,17 @@ import { Community, CommunitySchema } from '@schemas/community.schema';
 import { CommunityRepository } from '@repository/community.repository';
 import { UserRepository } from '@repository/user.repository';
 import { UserModule } from '@user/user.module';
+import { ChannelModule } from '@api/src/channel/channel.module';
+import { ChannelRepository } from '@repository/channel.repository';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Community.name, schema: CommunitySchema }]),
     UserModule,
+    forwardRef(() => ChannelModule),
   ],
   controllers: [CommunityController],
-  providers: [CommunityService, CommunityRepository, UserRepository],
+  providers: [CommunityService, CommunityRepository, UserRepository, ChannelRepository],
   exports: [MongooseModule],
 })
 export class CommunityModule {}

--- a/server/apps/api/src/community/dto/community-basic-info.dto.ts
+++ b/server/apps/api/src/community/dto/community-basic-info.dto.ts
@@ -1,0 +1,10 @@
+export const getCommunityBasicInfo = (community, channels) => {
+  return {
+    _id: community._id,
+    name: community.name,
+    managerId: community.managerId,
+    profileUrl: community.profileUrl,
+    description: community.description,
+    channels,
+  };
+};

--- a/server/dao/repository/channel.repository.ts
+++ b/server/dao/repository/channel.repository.ts
@@ -19,4 +19,12 @@ export class ChannelRepository {
   async updateOne(filter, updateField) {
     return await this.channelModel.updateOne(filter, updateField);
   }
+
+  async findById(_id: string) {
+    return await this.channelModel.findById(_id);
+  }
+
+  async findOr(conditions: any) {
+    return await this.channelModel.find({ $or: conditions });
+  }
 }


### PR DESCRIPTION
## Issues
- #115 

## 🤷‍♂️ Description

현재 사용자가 속한 커뮤니티 및 채널들의 기본 Data form 완성하였으며,
[이전 PR](https://github.com/boostcampwm-2022/web24-Asnity/pull/129) 과 이어집니다.

커뮤니티 기본 정보 form
```
return {
    _id: community._id,
    name: community.name,
    managerId: community.managerId,
    profileUrl: community.profileUrl,
    description: community.description,
    channels,
  };
```
커뮤니티 내 채널 기본 정보 from
```
return {
    _id: channel._id,
    name: channel.name,
    managerId: channel.managerId,
    type: channel.type,
    isPrivate: channel.isPrivate,
    profileUrl: channel.profileUrl,
    description: channel.description,
    lastRead: boolean
  };
```

## 📷 Screenshots

- 정상 동작

![image](https://user-images.githubusercontent.com/34162358/204018642-02b168dd-078c-43ad-b84d-a89f580fee38.png)

-  사용자 doc 내부 communit _id 이상

![image](https://user-images.githubusercontent.com/34162358/204018706-8b07d168-8c4d-41a7-8934-4b9d366192ee.png)

- 사용자 doc 내부 적힌 채널 _id 이상

![image](https://user-images.githubusercontent.com/34162358/204018970-5a4a031f-5fbb-4c20-a374-459f5e39fe15.png)

- 사용자 doc 내부 적힌 채널 _id가 실제 커뮤니티 doc에 없을 때 

![image](https://user-images.githubusercontent.com/34162358/204019013-b3a65794-2536-49f3-a263-2e2a3dcf3220.png)
