### PR TITLE
[CLIENT] `CommunityNav` 채널 목록 보여주기

### DIFF
--- a/client/src/apis/channel.ts
+++ b/client/src/apis/channel.ts
@@ -1,0 +1,26 @@
+import type { SuccessResponse } from '@@types/apis/response';
+import type { User } from '@apis/user';
+
+import { tokenAxios } from '@utils/axios';
+
+export interface Channel {
+  id: string;
+  managerId: User['_id'];
+  name: string;
+  users: Array<User['_id']>;
+  profileUrl: string;
+  description: string;
+  isPrivate: boolean;
+}
+
+export type GetChannelsResult = Channel[];
+export type GetChannelsResponse = SuccessResponse<GetChannelsResult>;
+export type GetChannels = (communityId: string) => Promise<GetChannelsResult>;
+
+export const getChannels: GetChannels = (communityId: string) => {
+  const endPoint = `/api/user/community/${communityId}/channels`;
+
+  return tokenAxios
+    .get<GetChannelsResponse>(endPoint)
+    .then((response) => response.data.result);
+};

--- a/client/src/components/ChannelItem/index.tsx
+++ b/client/src/components/ChannelItem/index.tsx
@@ -1,15 +1,13 @@
-import type { ComponentPropsWithoutRef } from 'react';
-
 import { HashtagIcon, LockClosedIcon } from '@heroicons/react/20/solid';
 import React from 'react';
 
-interface Props extends ComponentPropsWithoutRef<'li'> {
+interface Props {
   isPrivate?: boolean;
   name: string;
 }
 const ChannelItem: React.FC<Props> = ({ isPrivate = true, name }) => {
   return (
-    <li className="flex items-center gap-[5px] pl-[40px] h-[45px] select-none">
+    <div className="flex items-center gap-[5px] h-[45px] select-none">
       <div>
         {isPrivate ? (
           <>
@@ -24,7 +22,7 @@ const ChannelItem: React.FC<Props> = ({ isPrivate = true, name }) => {
         )}
       </div>
       <div className="text-s18">{name}</div>
-    </li>
+    </div>
   );
 };
 

--- a/client/src/components/ChannelItem/index.tsx
+++ b/client/src/components/ChannelItem/index.tsx
@@ -1,0 +1,31 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { HashtagIcon, LockClosedIcon } from '@heroicons/react/20/solid';
+import React from 'react';
+
+interface Props extends ComponentPropsWithoutRef<'li'> {
+  isPrivate?: boolean;
+  name: string;
+}
+const ChannelItem: React.FC<Props> = ({ isPrivate = true, name }) => {
+  return (
+    <li className="flex items-center gap-[5px] pl-[40px] h-[45px] select-none">
+      <div>
+        {isPrivate ? (
+          <>
+            <span className="sr-only">비공개 채널</span>
+            <LockClosedIcon className="w-5 h-5" />
+          </>
+        ) : (
+          <>
+            <span className="sr-only">공개 채널</span>
+            <HashtagIcon className="w-5 h-5" />
+          </>
+        )}
+      </div>
+      <div className="text-s18">{name}</div>
+    </li>
+  );
+};
+
+export default ChannelItem;

--- a/client/src/hooks/channel.ts
+++ b/client/src/hooks/channel.ts
@@ -1,0 +1,23 @@
+import type { GetChannelsResult } from '@apis/channel';
+import type { AxiosError } from 'axios';
+
+import { getChannels } from '@apis/channel';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import queryKeyCreator from '@/queryKeyCreator';
+
+export const useChannelsQuery = (communityId: string) => {
+  const queryClient = useQueryClient();
+  const key = queryKeyCreator.channel.list(communityId);
+
+  const query = useQuery<GetChannelsResult, AxiosError>(key, () =>
+    getChannels(communityId),
+  );
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries(key),
+    [queryClient, key],
+  );
+
+  return { channelsQuery: query, invalidateChannelsQuery: invalidate };
+};

--- a/client/src/layouts/CommunityNav/index.tsx
+++ b/client/src/layouts/CommunityNav/index.tsx
@@ -56,21 +56,22 @@ const CommunityNav = () => {
         ) : (
           <ul className="flex flex-col">
             {channelsQuery.data?.map((channel) => (
-              <Link
-                to={`/communities/${communityId}/channels/${channel.id}`}
+              <li
                 key={channel.id}
-                className={classNames({
+                className={classNames('pl-[40px]', {
                   hidden: !visible && channel.id !== roomId,
                   'text-placeholder hover:bg-offWhite': channel.id !== roomId,
                   'bg-indigo text-offWhite hover:bg-indigo hover:text-offwhite':
                     channel.id === roomId,
                 })}
               >
-                <ChannelItem
-                  name={channel.name}
-                  isPrivate={channel.isPrivate}
-                />
-              </Link>
+                <Link to={`/communities/${communityId}/channels/${channel.id}`}>
+                  <ChannelItem
+                    name={channel.name}
+                    isPrivate={channel.isPrivate}
+                  />
+                </Link>
+              </li>
             ))}
           </ul>
         )}

--- a/client/src/layouts/CommunityNav/index.tsx
+++ b/client/src/layouts/CommunityNav/index.tsx
@@ -1,6 +1,14 @@
+import ChannelItem from '@components/ChannelItem';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  PlusIcon,
+} from '@heroicons/react/20/solid';
+import { useChannelsQuery } from '@hooks/channel';
 import { useCommunitiesQuery } from '@hooks/community';
-import React from 'react';
-import { useParams } from 'react-router-dom';
+import classNames from 'classnames';
+import React, { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
 
 const CommunityNav = () => {
   const { communityId } = useParams();
@@ -9,11 +17,64 @@ const CommunityNav = () => {
     ({ _id }) => _id === communityId,
   );
 
+  const { roomId } = useParams();
+  const { channelsQuery } = useChannelsQuery(communityId as string);
+  const [visible, setVisible] = useState(true);
+
+  const handleVisible = () => setVisible(!visible);
+
   return (
     <nav className="flex flex-col flex-1">
       <header className="flex items-center px-[22px] w-full h-header border-b border-line font-ipSans text-title select-none">
         {communitySummary?.name}
       </header>
+      <div className="flex flex-col w-full">
+        <div className="flex justify-between items-center py-[16px] px-[12px]">
+          <div className="flex gap-[8px]">
+            <button onClick={handleVisible}>
+              {visible ? (
+                <>
+                  <span className="sr-only">채널 목록 접기</span>
+                  <ChevronDownIcon className="w-[20px] h-[20px] fill-titleActive" />
+                </>
+              ) : (
+                <>
+                  <span className="sr-only">채널 목록 펼치기</span>
+                  <ChevronRightIcon className="w-[20px] h-[20px] fill-titleActive" />
+                </>
+              )}
+            </button>
+            <span className="text-s18 font-bold">참여중인 채널</span>
+          </div>
+          <button>
+            <span className="sr-only">채널 생성</span>
+            <PlusIcon className="w-5 h-5 fill-titleActive" />
+          </button>
+        </div>
+        {channelsQuery.isLoading ? (
+          <div>loading...</div>
+        ) : (
+          <ul className="flex flex-col">
+            {channelsQuery.data?.map((channel) => (
+              <Link
+                to={`/communities/${communityId}/channels/${channel.id}`}
+                key={channel.id}
+                className={classNames({
+                  hidden: !visible && channel.id !== roomId,
+                  'text-placeholder hover:bg-offWhite': channel.id !== roomId,
+                  'bg-indigo text-offWhite hover:bg-indigo hover:text-offwhite':
+                    channel.id === roomId,
+                })}
+              >
+                <ChannelItem
+                  name={channel.name}
+                  isPrivate={channel.isPrivate}
+                />
+              </Link>
+            ))}
+          </ul>
+        )}
+      </div>
     </nav>
   );
 };

--- a/client/src/layouts/CommunityNav/index.tsx
+++ b/client/src/layouts/CommunityNav/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@heroicons/react/20/solid';
 import { useChannelsQuery } from '@hooks/channel';
 import { useCommunitiesQuery } from '@hooks/community';
-import classNames from 'classnames';
+import cn from 'classnames';
 import React, { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 
@@ -58,7 +58,7 @@ const CommunityNav = () => {
             {channelsQuery.data?.map((channel) => (
               <li
                 key={channel.id}
-                className={classNames('pl-[40px]', {
+                className={cn('pl-[40px]', {
                   hidden: !visible && channel.id !== roomId,
                   'text-placeholder hover:bg-offWhite': channel.id !== roomId,
                   'bg-indigo text-offWhite hover:bg-indigo hover:text-offwhite':

--- a/client/src/mocks/data/channels.js
+++ b/client/src/mocks/data/channels.js
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker';
+
+import { chancify, getRandomBool } from '../utils/rand';
+
+export const createChannels = () => ({
+  id: faker.datatype.uuid(),
+  managerId: faker.datatype.uuid(),
+  name: faker.lorem.word(),
+  users: [...Array(10)].map(() => faker.datatype.uuid()),
+  profileUrl: chancify(() => faker.image.avatar(), 50),
+  description: faker.lorem.sentence(1),
+  isPrivate: getRandomBool(),
+});
+
+export const channels = [...Array(10)].map(createChannels);

--- a/client/src/mocks/handlers/Channel.js
+++ b/client/src/mocks/handlers/Channel.js
@@ -1,0 +1,27 @@
+import { API_URL } from '@constants/url';
+import { rest } from 'msw';
+
+import { channels } from '../data/channels';
+import {
+  createErrorContext,
+  createSuccessContext,
+} from '../utils/createContext';
+
+const BASE_URL = `${API_URL}/api`;
+
+// 채널 목록 가져오기
+const GetChannels = rest.get(
+  `${BASE_URL}/user/community/:communityId/channels`,
+  (req, res, ctx) => {
+    const ERROR = false;
+
+    const errorResponse = res(...createErrorContext(ctx));
+    const successResponse = res(
+      ...createSuccessContext(ctx, 200, 500, channels),
+    );
+
+    return ERROR ? errorResponse : successResponse;
+  },
+);
+
+export default [GetChannels];

--- a/client/src/mocks/handlers/index.js
+++ b/client/src/mocks/handlers/index.js
@@ -1,4 +1,5 @@
 import AuthHandlers from './Auth';
+import ChannelHandlers from './Channel';
 import CommunityHandlers from './Community';
 import DMHandlers from './DM';
 import FriendHandlers from './Friend';
@@ -10,4 +11,5 @@ export const handlers = [
   ...UserHandlers,
   ...DMHandlers,
   ...CommunityHandlers,
+  ...ChannelHandlers,
 ];

--- a/client/src/mocks/utils/rand.js
+++ b/client/src/mocks/utils/rand.js
@@ -2,6 +2,8 @@ export const getRandomInt = (max) => {
   return Math.floor(Math.random() * max);
 };
 
+export const getRandomBool = () => Boolean(getRandomInt(2));
+
 /**
  * @param fn {Function} 실행할 함수
  * @param percent {number} 0 ~ 100 사이의 숫자

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -9,6 +9,12 @@ const communityQueryKey = {
   createCommunity: () => ['createCommunity'] as const,
 };
 
+const channelQueryKey = {
+  all: () => ['channels'] as const,
+  list: (communityId: string) =>
+    [...channelQueryKey.all(), communityId] as const,
+};
+
 const queryKeyCreator = {
   me: () => ['me'] as const,
   signUp: () => ['signUp'] as const,
@@ -19,6 +25,7 @@ const queryKeyCreator = {
   userSearch: (filter: string) => ['userSearch', { filter }],
   directMessage: directMessageQueryKey,
   community: communityQueryKey,
+  channel: channelQueryKey,
 } as const;
 
 export default queryKeyCreator;


### PR DESCRIPTION
## Issues
- #151 

## 🤷‍♂️ Description

커뮤니티 페이지에 들어가면 채널 목록을 사이드바에 렌더링한다.


## 📝 Primary Commits

- [X] 현재 참여중인 채널 목록을 렌더링한다.
- [X] 채널 아이템을 누르면 해당 채팅방으로 라우팅한다.
- [X] 현재 접속한 채널 아이템과 그렇지 않은 채널 아이템을 다르게 보여준다.
- [X] 화살표를 눌러 채널 목록을 접고 편다.

## 📷 Screenshots

![Animation](https://user-images.githubusercontent.com/57662010/204124227-3d0cced3-7f6b-49b3-a40e-266d2c8cf780.gif)


 
## 📒 Remarks

- [ ] 커뮤니티 페이지로 들어왔을 때 기본으로 보여줄 채널 페이지로 라우팅해야함
- [ ] 새로운 메시지가 있는 경우 항목 오른쪽에 표시해주어야함
- [ ] 채널 생성하기 기능 추가해야함
- [ ] 오른쪽 마우스 버튼으로 항목 클릭시 컨텍스트 메뉴 띄워줘야함
- [ ] `참여할 수 있는 채널` 목록 렌더링해야함