### PR TITLE
[Server/channel exit] 채널 퇴장 로직 구현 및 accessToken 검증 로직 수정

### DIFF
--- a/server/apps/api/src/auth/strategy/jwt-access.strategy.ts
+++ b/server/apps/api/src/auth/strategy/jwt-access.strategy.ts
@@ -1,12 +1,11 @@
 import { PassportStrategy } from '@nestjs/passport';
-import { UserRepository } from '@repository/user.repository';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
-import { ForbiddenException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class JwtAccessStrategy extends PassportStrategy(Strategy, 'jwt-access-token') {
-  constructor(config: ConfigService, private userRepository: UserRepository) {
+  constructor(config: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       secretOrKey: config.get('JWT_SECRET'),
@@ -14,11 +13,6 @@ export class JwtAccessStrategy extends PassportStrategy(Strategy, 'jwt-access-to
   }
 
   async validate(payload: any) {
-    const user = await this.userRepository.findById(payload._id);
-    if (!user) {
-      throw new ForbiddenException('잘못된 요청입니다.');
-    }
-    delete user.password;
-    return { ...user, _id: user._id.toString() };
+    return payload._id;
   }
 }

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Inject,
   LoggerService,
   Patch,
@@ -13,6 +14,7 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ChannelService } from '@channel/channel.service';
 import { CreateChannelDto, ModifyChannelDto } from '@channel/dto';
 import { JwtAccessGuard } from '@auth/guard';
+import { ExitChannelDto } from '@channel/dto/exit-channel.dto';
 
 @Controller('api/channel')
 export class ChannelController {
@@ -41,6 +43,19 @@ export class ChannelController {
     try {
       await this.channelService.modifyChannel({ ...modifyChannelDto, managerId: _id });
       return responseForm(200, { message: '채널 수정 성공!' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+
+  @Delete('exit')
+  @UseGuards(JwtAccessGuard)
+  async exitChannel(@Body() exitChannelDto: ExitChannelDto, @Req() req: any) {
+    const user_id = req.user._id;
+    try {
+      await this.channelService.exitChannel({ ...exitChannelDto, user_id });
+      return responseForm(200, { message: '채널 퇴장 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
       throw error;

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -76,7 +76,6 @@ export class ChannelService {
   }
 
   async exitChannel(exitChannelDto: ExitChannelDto) {
-    console.log('userId : ', exitChannelDto.user_id);
     // channel도큐먼트에 users필드에서 user_id 제거
     await this.channelRepository.deleteElementAtArr(
       { _id: exitChannelDto.channel_id },
@@ -87,7 +86,6 @@ export class ChannelService {
       exitChannelDto.community_id,
       exitChannelDto.channel_id,
     );
-    console.log(deleteChannel);
     await this.userRepository.deleteObject({ _id: exitChannelDto.user_id }, deleteChannel);
   }
 }

--- a/server/apps/api/src/channel/dto/exit-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/exit-channel.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class ExitChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  community_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  channel_id: string;
+
+  @IsString()
+  @IsOptional()
+  user_id: string;
+}

--- a/server/apps/api/src/channel/helper/addObjectForm.ts
+++ b/server/apps/api/src/channel/helper/addObjectForm.ts
@@ -1,4 +1,4 @@
-export function addChannelToUserForm(communityId, channelId) {
+export function getChannelToUserForm(communityId, channelId) {
   return {
     [`communities.${communityId.toString()}.channels.${channelId.toString()}`]: new Date(),
   };

--- a/server/dao/repository/channel.repository.ts
+++ b/server/dao/repository/channel.repository.ts
@@ -20,6 +20,12 @@ export class ChannelRepository {
     return await this.channelModel.updateOne(filter, updateField);
   }
 
+  async deleteElementAtArr(filter, removeElement) {
+    return await this.channelModel.updateOne(filter, {
+      $pullAll: removeElement,
+    });
+  }
+
   async findById(_id: string) {
     return await this.channelModel.findById(_id);
   }


### PR DESCRIPTION
## Issues
- #143
- #11 

## 🤷‍♂️ Description

- 채널 퇴장 로직 작성
  - channel 도큐먼트의 users 필드에서 사용자 제거
  - user 도큐먼트의 communities:channels 필드에서 사용자 제거

- Access Token을 검증할 때 DB에서 user가 존재하는 지 확인하는 로직 제거
  - DB에 접근하게 되면 JWT의 장점(토큰을 복호화하면 정보를 알 수 있어서 서버 부담 줄이는)을 없앤다고 생각함
  - "확인하는 로직이 없으면 사용자가 악용하면 어떻게 하지?" 라는 의문이 생김
    - JWT안에 유저 정보가 암호화 되어있음, 서버의 secret key가 없으면 해독 불가능 -> JwtAccessGuard가 잘못된 accessToken이면 unauthorization 에러를 내보내서 그럴 일은 거의 없을 것

## 📷 Screenshots

채널 퇴장 성공 시
<img width="358" alt="스크린샷 2022-11-27 오후 6 08 41" src="https://user-images.githubusercontent.com/72093196/204127351-7f5711f7-d44e-4a51-a9d8-96924e71d766.png">

 
## 📒 Remarks

관리자가 채널 삭제 시 로직은 내일 회의 때 클라이언트에서 처리할 지 서버에서 처리할 지 얘기 나눠보고 구현할께요!
- 채널에 혼자 존재 : 삭제 가능
- 채널에 다른 유저 존재 : 관리자 변경 필요
  - 클라이언트에서 해준다면, 관리자 변경을 클라이언트에서 요청을 보내고 성공하면 삭제요청을 보냄
  - 서버에서 해준다면, 관리자가 삭제를 요청한다고 에러처리 필요
