### PR TITLE
[Feature/channel] 채널 정보 API, 채널 삭제 API 구현

### DIFF
--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -50,16 +50,12 @@ export class ChannelController {
     }
   }
 
-  @Delete('user/:community_id/:channel_id')
+  @Delete('user/:channel_id')
   @UseGuards(JwtAccessGuard)
-  async exitChannel(
-    @Param('community_id') community_id,
-    @Param('channel_id') channel_id,
-    @Req() req: any,
-  ) {
+  async exitChannel(@Param('channel_id') channel_id, @Req() req: any) {
     const user_id = req.user._id;
     try {
-      await this.channelService.exitChannel({ community_id, channel_id, user_id });
+      await this.channelService.exitChannel({ channel_id, user_id });
       return responseForm(200, { message: '채널 퇴장 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
@@ -78,7 +74,12 @@ export class ChannelController {
   @UseGuards(JwtAccessGuard)
   async deleteChannel(@Param('channel_id') channel_id, @Req() req) {
     const user_id = req.user;
-    await this.channelService.deleteChannel({ channel_id, user_id });
-    return responseForm(200, { message: '채널 삭제 성공' });
+    try {
+      await this.channelService.deleteChannel({ channel_id, user_id });
+      return responseForm(200, { message: '채널 삭제 성공' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
   }
 }

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -14,9 +14,8 @@ import {
 import { responseForm } from '@utils/responseForm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ChannelService } from '@channel/channel.service';
-import { CreateChannelDto, ModifyChannelDto } from '@channel/dto';
+import { CreateChannelDto, DeleteChannelDto, ModifyChannelDto } from '@channel/dto';
 import { JwtAccessGuard } from '@auth/guard';
-import { ExitChannelDto } from '@channel/dto/exit-channel.dto';
 
 @Controller('api/channel')
 export class ChannelController {
@@ -51,12 +50,16 @@ export class ChannelController {
     }
   }
 
-  @Delete('exit')
+  @Delete(':community_id/user/:channel_id')
   @UseGuards(JwtAccessGuard)
-  async exitChannel(@Body() exitChannelDto: ExitChannelDto, @Req() req: any) {
+  async exitChannel(
+    @Param('community_id') community_id,
+    @Param('channel_id') channel_id,
+    @Req() req: any,
+  ) {
     const user_id = req.user._id;
     try {
-      await this.channelService.exitChannel({ ...exitChannelDto, user_id });
+      await this.channelService.exitChannel({ community_id, channel_id, user_id });
       return responseForm(200, { message: '채널 퇴장 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -14,7 +14,7 @@ import {
 import { responseForm } from '@utils/responseForm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ChannelService } from '@channel/channel.service';
-import { CreateChannelDto, DeleteChannelDto, ModifyChannelDto } from '@channel/dto';
+import { CreateChannelDto, ModifyChannelDto } from '@channel/dto';
 import { JwtAccessGuard } from '@auth/guard';
 
 @Controller('api/channel')
@@ -50,7 +50,7 @@ export class ChannelController {
     }
   }
 
-  @Delete(':community_id/user/:channel_id')
+  @Delete('user/:community_id/:channel_id')
   @UseGuards(JwtAccessGuard)
   async exitChannel(
     @Param('community_id') community_id,
@@ -70,6 +70,15 @@ export class ChannelController {
   @Get(':id')
   @UseGuards(JwtAccessGuard)
   async getChannelInfo(@Param('id') channel_id: string) {
-    return await this.channelService.getChannelInfo(channel_id);
+    const channelInfo = await this.channelService.getChannelInfo(channel_id);
+    return responseForm(200, channelInfo);
+  }
+
+  @Delete(':channel_id')
+  @UseGuards(JwtAccessGuard)
+  async deleteChannel(@Param('channel_id') channel_id, @Req() req) {
+    const user_id = req.user;
+    await this.channelService.deleteChannel({ channel_id, user_id });
+    return responseForm(200, { message: '채널 삭제 성공' });
   }
 }

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -2,8 +2,10 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   Inject,
   LoggerService,
+  Param,
   Patch,
   Post,
   Req,
@@ -60,5 +62,11 @@ export class ChannelController {
       this.logger.error(JSON.stringify(error.response));
       throw error;
     }
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAccessGuard)
+  async getChannelInfo(@Param('id') channel_id: string) {
+    return await this.channelService.getChannelInfo(channel_id);
   }
 }

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -87,7 +87,8 @@ export class ChannelService {
   }
 
   async getChannelInfo(channel_id) {
-    return await this.channelRepository.findOne({ _id: channel_id });
+    const channelInfo = await this.channelRepository.findOne({ _id: channel_id });
+    return JSON.parse(JSON.stringify(channelInfo));
   }
 
   async deleteChannel(deleteChannelDto: DeleteChannelDto) {

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -3,7 +3,7 @@ import { ChannelRepository } from '@repository/channel.repository';
 import { CommunityRepository } from '@repository/community.repository';
 import { UserRepository } from '@repository/user.repository';
 import { getChannelToUserForm } from '@channel/helper/addObjectForm';
-import { CreateChannelDto, ModifyChannelDto } from '@channel/dto';
+import { CreateChannelDto, DeleteChannelDto, ModifyChannelDto } from '@channel/dto';
 import { ExitChannelDto } from '@channel/dto/exit-channel.dto';
 
 @Injectable()
@@ -91,5 +91,35 @@ export class ChannelService {
 
   async getChannelInfo(channel_id) {
     return await this.channelRepository.findOne({ _id: channel_id });
+  }
+
+  async deleteChannel(deleteChannelDto: DeleteChannelDto) {
+    const { channel_id, user_id } = deleteChannelDto;
+    // 관리자가 아니면 채널 삭제 에러 처리
+    const channel = await this.channelRepository.findOne({ _id: channel_id });
+    if (user_id !== channel.managerId) {
+      throw new BadRequestException('관리자가 아닙니다!');
+    }
+
+    // channel에 속한 모든 user들에 대하여 user 도큐먼트에 communities:channels 필드 수정
+    await Promise.all(
+      channel.users.map((user) => {
+        this.userRepository.deleteObject(
+          { _id: user },
+          getChannelToUserForm(channel.communityId, channel_id),
+        );
+      }),
+    );
+
+    // channel 도큐먼트 softDelete
+    const updateField = { deletedAt: new Date() };
+    await this.channelRepository.findAndUpdateOne(
+      {
+        _id: channel_id,
+        managerId: user_id,
+        deletedAt: { $exists: false },
+      },
+      updateField,
+    );
   }
 }

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -76,17 +76,14 @@ export class ChannelService {
   }
 
   async exitChannel(exitChannelDto: ExitChannelDto) {
+    const { channel_id, user_id } = exitChannelDto;
     // channel도큐먼트에 users필드에서 user_id 제거
-    await this.channelRepository.deleteElementAtArr(
-      { _id: exitChannelDto.channel_id },
-      { users: [exitChannelDto.user_id] },
-    );
+    await this.channelRepository.deleteElementAtArr({ _id: channel_id }, { users: [user_id] });
+    const channel = await this.channelRepository.findOne({ _id: channel_id });
+
     // user도큐먼트에 community 필드에 channel_id 제거
-    const deleteChannel = getChannelToUserForm(
-      exitChannelDto.community_id,
-      exitChannelDto.channel_id,
-    );
-    await this.userRepository.deleteObject({ _id: exitChannelDto.user_id }, deleteChannel);
+    const deleteChannel = getChannelToUserForm(channel.communityId, channel_id);
+    await this.userRepository.deleteObject({ _id: user_id }, deleteChannel);
   }
 
   async getChannelInfo(channel_id) {

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -88,4 +88,8 @@ export class ChannelService {
     );
     await this.userRepository.deleteObject({ _id: exitChannelDto.user_id }, deleteChannel);
   }
+
+  async getChannelInfo(channel_id) {
+    return await this.channelRepository.findOne({ _id: channel_id });
+  }
 }

--- a/server/apps/api/src/channel/dto/delete-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/delete-channel.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class DeleteChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  channel_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  user_id: string;
+}

--- a/server/apps/api/src/channel/dto/exit-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/exit-channel.dto.ts
@@ -1,15 +1,11 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class ExitChannelDto {
-  @IsString()
-  @IsNotEmpty()
-  community_id: string;
-
   @IsString()
   @IsNotEmpty()
   channel_id: string;
 
   @IsString()
-  @IsOptional()
+  @IsNotEmpty()
   user_id: string;
 }

--- a/server/apps/api/src/channel/dto/index.ts
+++ b/server/apps/api/src/channel/dto/index.ts
@@ -1,2 +1,4 @@
 export * from './create-channel.dto';
 export * from './modify-channel.dto';
+export * from './exit-channel.dto';
+export * from './delete-channel.dto';

--- a/server/dao/repository/channel.repository.ts
+++ b/server/dao/repository/channel.repository.ts
@@ -34,6 +34,10 @@ export class ChannelRepository {
     return await this.channelModel.find({ $or: conditions });
   }
 
+  async findAndUpdateOne(filter, updateField) {
+    return await this.channelModel.findOneAndUpdate(filter, updateField, { new: true });
+  }
+
   async addArrAtArr(filter, attribute, appendArr) {
     const addArr = {};
     addArr[attribute] = { $each: appendArr };


### PR DESCRIPTION
## Issues
- #144 
- #145 

## 🤷‍♂️ Description

- 채널 정보 전달하는 로직 구현 (`GET api/channel/:id`)
- 채널 삭제하는 로직 구현 (`DELETE api/channel/:channel_id`)



## 📝 Primary Commits

>**채널 정보 전달** 
- #144 
- [x]  channel.controller
    - `Get api/channel/:id`
    - getChannelInfo
- [x]  channel.service
    - getChannelInfo
    - ~~ChannelBasicInfo로 감싸기~~
- [x]  channel.repository
    - findOne
- [ ] ~~에러 처리~~
    - ~~채널 id가 존재하지 않으면 에러~~

>**채널 삭제**
- [x]  채널 삭제를 위한 dto 작성

```tsx
channel_id: String, NotEmpty
user_id: String, NotEmpty
```

- [x]  channel.controller
    - `Delete /api/channel/:channel_id`
    - `UseGuard(JwtAccessGuard)`
    - deleteChannel
- [x]  channel.service
    - channel에 속한 user들에 대하여
        - user 도큐먼트에 community 필드에 channelId 제거
    - channel도큐먼트 softDelete
- [x]  에러 처리
    - userId가 채널의 managerId와 일치하지 않으면 에러

## 📷 Screenshots
>**채널 정보**
- 성공
<img width="482" alt="스크린샷 2022-11-27 오후 11 20 17" src="https://user-images.githubusercontent.com/72093196/204140140-e22aa1d1-30a0-4a6c-ae29-ee78f47a0eb2.png">

>**채널 삭제**
- 성공
<img width="349" alt="스크린샷 2022-11-27 오후 11 10 02" src="https://user-images.githubusercontent.com/72093196/204139643-c88b8b79-a1c4-43e1-91d5-bd2aaac439c5.png">

- 실패 (채널 관리자가 아닐 경우)
<img width="407" alt="스크린샷 2022-11-27 오후 11 10 38" src="https://user-images.githubusercontent.com/72093196/204139671-d8941e1b-5aa6-40e7-a823-8ecae3f4cd88.png">


