### PR TITLE
[CLIENT] Channel metadata 렌더링

### DIFF
--- a/client/src/apis/channel.ts
+++ b/client/src/apis/channel.ts
@@ -3,7 +3,7 @@ import type { User } from '@apis/user';
 
 import { tokenAxios } from '@utils/axios';
 
-export interface Channel {
+export interface ChannelSummary {
   id: string;
   managerId: User['_id'];
   name: string;
@@ -13,7 +13,7 @@ export interface Channel {
   isPrivate: boolean;
 }
 
-export type GetChannelsResult = Channel[];
+export type GetChannelsResult = ChannelSummary[];
 export type GetChannelsResponse = SuccessResponse<GetChannelsResult>;
 export type GetChannels = (communityId: string) => Promise<GetChannelsResult>;
 
@@ -22,5 +22,26 @@ export const getChannels: GetChannels = (communityId: string) => {
 
   return tokenAxios
     .get<GetChannelsResponse>(endPoint)
+    .then((response) => response.data.result);
+};
+
+export interface Channel extends ChannelSummary {
+  communityId: string;
+  type: 'Channel';
+  users: Array<User['id']>;
+  chatLists: [];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type GetChannelResult = Channel;
+export type GetChannelResponse = SuccessResponse<GetChannelResult>;
+export type GetChannel = (channelId: string) => Promise<GetChannelResult>;
+
+export const getChannel: GetChannel = (channelId: string) => {
+  const endPoint = `/api/channels/${channelId}`;
+
+  return tokenAxios
+    .get<GetChannelResponse>(endPoint)
     .then((response) => response.data.result);
 };

--- a/client/src/apis/community.ts
+++ b/client/src/apis/community.ts
@@ -23,6 +23,17 @@ export const getCommunities: GetCommunities = () => {
     .then((response) => response.data.result);
 };
 
+export type GetCommunityResult = CommunitySummary;
+export type GetCommunity = (communityId: string) => Promise<GetCommunityResult>;
+export type GetCommunityResponse = SuccessResponse<GetCommunityResult>;
+export const getCommunity: GetCommunity = (communityId: string) => {
+  const endPoint = `/api/communities/${communityId}`;
+
+  return tokenAxios
+    .get<GetCommunityResponse>(endPoint)
+    .then((response) => response.data.result);
+};
+
 export interface CreateCommunityRequest {
   name: string;
   description: string;

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -1,6 +1,7 @@
 import type { SuccessResponse } from '@@types/apis/response';
 
 import { API_URL } from '@constants/url';
+import { tokenAxios } from '@utils/axios';
 import axios from 'axios';
 
 export type UserStatus = 'online' | 'offline' | 'afk';
@@ -61,3 +62,15 @@ export type GetUsersResponse = SuccessResponse<GetUsersResult>;
 
 export const GetUsers = (params: GetUsersParams): Promise<GetUsersResponse> =>
   axios.get(`${API_URL}/api/users`, { params }).then((res) => res.data);
+
+export type GetUserResult = User;
+export type GetUserResponse = SuccessResponse<GetUserResult>;
+export type GetUser = (userId: string) => Promise<GetUserResult>;
+
+export const getUser: GetUser = (userId: string) => {
+  const endPoint = `${API_URL}/api/users/${userId}`;
+
+  return tokenAxios
+    .get<GetUserResponse>(endPoint)
+    .then((response) => response.data.result);
+};

--- a/client/src/components/ChannelItem/index.tsx
+++ b/client/src/components/ChannelItem/index.tsx
@@ -4,10 +4,16 @@ import React from 'react';
 interface Props {
   isPrivate?: boolean;
   name: string;
+  className?: string;
 }
-const ChannelItem: React.FC<Props> = ({ isPrivate = true, name }) => {
+
+const ChannelItem: React.FC<Props> = ({
+  isPrivate = true,
+  name,
+  className,
+}) => {
   return (
-    <div className="flex items-center gap-[5px] h-[45px] select-none">
+    <div className={`flex items-center gap-[5px] select-none ${className}`}>
       <div>
         {isPrivate ? (
           <>

--- a/client/src/components/ChannelMetadata/index.tsx
+++ b/client/src/components/ChannelMetadata/index.tsx
@@ -2,13 +2,8 @@ import type { FC } from 'react';
 
 import Avatar from '@components/Avatar';
 import ChannelItem from '@components/ChannelItem';
+import { formatDate } from '@utils/date';
 import React from 'react';
-
-const formatDate = (str: string) => {
-  const d = new Date(str);
-
-  return { year: d.getFullYear(), month: d.getMonth() + 1, date: d.getDate() };
-};
 
 interface Props {
   profileUrl: string;
@@ -25,8 +20,6 @@ const ChannelMetadata: FC<Props> = ({
   isPrivate,
   createdAt,
 }) => {
-  const { year, month, date } = formatDate(createdAt);
-
   return (
     <div className="flex min-w-max min-h-[55px] items-center gap-2">
       <div>
@@ -47,8 +40,8 @@ const ChannelMetadata: FC<Props> = ({
           의 시작이에요.
         </div>
         <div>
-          <span className="font-bold">@{managerName}</span>님이 이 채널을 {year}
-          년 {month}월 {date}일에 생성했습니다.
+          <span className="font-bold">@{managerName}</span>님이 이 채널을{' '}
+          {formatDate(createdAt)}에 생성했습니다.
         </div>
       </div>
     </div>

--- a/client/src/components/ChannelMetadata/index.tsx
+++ b/client/src/components/ChannelMetadata/index.tsx
@@ -1,0 +1,58 @@
+import type { FC } from 'react';
+
+import Avatar from '@components/Avatar';
+import ChannelItem from '@components/ChannelItem';
+import React from 'react';
+
+const formatDate = (str: string) => {
+  const d = new Date(str);
+
+  return { year: d.getFullYear(), month: d.getMonth() + 1, date: d.getDate() };
+};
+
+interface Props {
+  profileUrl: string;
+  channelName: string;
+  isPrivate: boolean;
+  createdAt: string;
+  managerName: string;
+}
+
+const ChannelMetadata: FC<Props> = ({
+  profileUrl,
+  managerName,
+  channelName,
+  isPrivate,
+  createdAt,
+}) => {
+  const { year, month, date } = formatDate(createdAt);
+
+  return (
+    <div className="flex min-w-max min-h-[55px] items-center gap-2">
+      <div>
+        <Avatar
+          variant="rectangle"
+          size="small"
+          url={profileUrl}
+          name={channelName}
+        />
+      </div>
+      <div className="flex flex-col justify-center h-full">
+        <div className="flex items-center">
+          <ChannelItem
+            name={channelName}
+            isPrivate={isPrivate}
+            className="font-bold"
+          />
+          의 시작이에요.
+        </div>
+        <div>
+          <span className="font-bold">@{managerName}</span>님이 이 채널을 {year}
+          년 {month}월 {date}일에 생성했습니다.
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChannelMetadata;

--- a/client/src/hooks/channel.ts
+++ b/client/src/hooks/channel.ts
@@ -1,7 +1,7 @@
-import type { GetChannelsResult } from '@apis/channel';
+import type { GetChannelResult, GetChannelsResult } from '@apis/channel';
 import type { AxiosError } from 'axios';
 
-import { getChannels } from '@apis/channel';
+import { getChannel, getChannels } from '@apis/channel';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -20,4 +20,19 @@ export const useChannelsQuery = (communityId: string) => {
   );
 
   return { channelsQuery: query, invalidateChannelsQuery: invalidate };
+};
+
+export const useChannelQuery = (channelId: string) => {
+  const queryClient = useQueryClient();
+  const key = queryKeyCreator.channel.detail(channelId);
+
+  const query = useQuery<GetChannelResult, AxiosError>(key, () =>
+    getChannel(channelId),
+  );
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries(key),
+    [queryClient, key],
+  );
+
+  return { channelQuery: query, invalidateChannelQuery: invalidate };
 };

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -2,11 +2,12 @@ import type {
   CreateCommunityResult,
   CreateCommunityRequest,
   GetCommunitiesResult,
+  GetCommunityResult,
 } from '@apis/community';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
-import { createCommunity, getCommunities } from '@apis/community';
+import { getCommunity, createCommunity, getCommunities } from '@apis/community';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import queryKeyCreator from 'src/queryKeyCreator';
@@ -21,6 +22,21 @@ export const useCommunitiesQuery = () => {
   }, [queryClient, key]);
 
   return { communitiesQuery: query, invalidateCommunitiesQuery: invalidate };
+};
+
+export const useCommunityQuery = (communityId: string) => {
+  const queryClient = useQueryClient();
+
+  const key = queryKeyCreator.community.detail(communityId);
+  const query = useQuery<GetCommunityResult, AxiosError>(key, () =>
+    getCommunity(communityId),
+  );
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries(key),
+    [queryClient, key],
+  );
+
+  return { communityQuery: query, invalidateCommunityQuery: invalidate };
 };
 
 export const useCreateCommunityMutation = (

--- a/client/src/hooks/user.ts
+++ b/client/src/hooks/user.ts
@@ -1,0 +1,23 @@
+import { getUser } from '@apis/user';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import queryKeyCreator from '@/queryKeyCreator';
+
+export const useUserQuery = (
+  userId: string,
+  options: {
+    enabled?: boolean;
+  },
+) => {
+  const queryClient = useQueryClient();
+  const key = queryKeyCreator.user.detail(userId);
+
+  const query = useQuery(key, () => getUser(userId), options);
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries(key),
+    [queryClient, key],
+  );
+
+  return { userQuery: query, invalidateUserQuery: invalidate };
+};

--- a/client/src/layouts/CommunityNav/index.tsx
+++ b/client/src/layouts/CommunityNav/index.tsx
@@ -58,7 +58,7 @@ const CommunityNav = () => {
             {channelsQuery.data?.map((channel) => (
               <li
                 key={channel.id}
-                className={cn('pl-[40px]', {
+                className={cn('flex items-center py-[6px] pl-[40px]', {
                   hidden: !visible && channel.id !== roomId,
                   'text-placeholder hover:bg-offWhite': channel.id !== roomId,
                   'bg-indigo text-offWhite hover:bg-indigo hover:text-offwhite':

--- a/client/src/mocks/handlers/Channel.js
+++ b/client/src/mocks/handlers/Channel.js
@@ -1,7 +1,9 @@
 import { API_URL } from '@constants/url';
+import { faker } from '@faker-js/faker';
 import { rest } from 'msw';
 
 import { channels } from '../data/channels';
+import { users } from '../data/users';
 import {
   createErrorContext,
   createSuccessContext,
@@ -24,4 +26,27 @@ const GetChannels = rest.get(
   },
 );
 
-export default [GetChannels];
+const GetChannel = rest.get(
+  `${BASE_URL}/channels/:channelId`,
+  (req, res, ctx) => {
+    const { channelId } = req.params;
+    const ERROR = false;
+
+    const errorResponse = res(...createErrorContext(ctx));
+    const successResponse = res(
+      ...createSuccessContext(ctx, 200, 500, {
+        ...channels.find((channel) => channel.id === channelId),
+        communityId: faker.datatype.uuid(),
+        type: 'Channel',
+        users: users.slice(3, 10).map((user) => user._id),
+        chatLists: [],
+        createdAt: '2022-11-25T17:32:09.085Z',
+        updatedAt: '2022-11-25T17:32:09.085Z',
+      }),
+    );
+
+    return ERROR ? errorResponse : successResponse;
+  },
+);
+
+export default [GetChannels, GetChannel];

--- a/client/src/mocks/handlers/Community.js
+++ b/client/src/mocks/handlers/Community.js
@@ -24,6 +24,26 @@ const GetCommunities = rest.get(
   },
 );
 
+const GetCommunity = rest.get(
+  `${BASE_URL}/communities/:communityId`,
+  (req, res, ctx) => {
+    const { communityId } = req.params;
+    const ERROR = false;
+
+    const errorResponse = res(...createErrorContext(ctx));
+    const successResponse = res(
+      ...createSuccessContext(
+        ctx,
+        200,
+        500,
+        communities.find((community) => community._id === communityId),
+      ),
+    );
+
+    return ERROR ? errorResponse : successResponse;
+  },
+);
+
 // 커뮤니티 생성
 const CreateCommunity = rest.post(
   `${BASE_URL}/community`,
@@ -67,4 +87,4 @@ const CreateCommunity = rest.post(
   },
 );
 
-export default [GetCommunities, CreateCommunity];
+export default [GetCommunities, GetCommunity, CreateCommunity];

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -2,6 +2,10 @@ import { API_URL } from '@constants/url';
 import { rest } from 'msw';
 
 import { users } from '../data/users';
+import {
+  createErrorContext,
+  createSuccessContext,
+} from '../utils/createContext';
 
 const GetFilteredUsers = rest.get(`${API_URL}/api/users`, (req, res, ctx) => {
   const search = req.url.searchParams.get('search').toUpperCase();
@@ -22,4 +26,13 @@ const GetFilteredUsers = rest.get(`${API_URL}/api/users`, (req, res, ctx) => {
   );
 });
 
-export default [GetFilteredUsers];
+const GetUser = rest.get(`${API_URL}/api/users/:userId`, (req, res, ctx) => {
+  const ERROR = false;
+
+  const errorResponse = res(...createErrorContext(ctx));
+  const successResponse = res(...createSuccessContext(ctx, 200, 500, users[0]));
+
+  return ERROR ? errorResponse : successResponse;
+});
+
+export default [GetFilteredUsers, GetUser];

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -1,27 +1,23 @@
-import Avatar from '@components/Avatar';
 import ChannelMetadata from '@components/ChannelMetadata';
 import { useChannelQuery } from '@hooks/channel';
-import { useCommunityQuery } from '@hooks/community';
 import { useUserQuery } from '@hooks/user';
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
 const Channel = () => {
-  const { communityId, roomId } = useParams();
-  const { communityQuery } = useCommunityQuery(communityId as string);
+  const { roomId } = useParams();
   const { channelQuery } = useChannelQuery(roomId as string);
   const { userQuery } = useUserQuery(channelQuery.data?.managerId as string, {
     enabled: !!channelQuery.data?.managerId,
   });
 
-  if (channelQuery.isLoading || communityQuery.isLoading)
-    return <div>loading...</div>;
+  if (channelQuery.isLoading) return <div>loading...</div>;
 
   return (
     <div>
-      {channelQuery.data && userQuery.data && communityQuery.data && (
+      {channelQuery.data && userQuery.data && (
         <ChannelMetadata
-          profileUrl={communityQuery.data.profileUrl}
+          profileUrl={channelQuery.data.profileUrl}
           channelName={channelQuery.data.name}
           isPrivate={channelQuery.data.isPrivate}
           createdAt={channelQuery.data.createdAt}

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -1,7 +1,35 @@
+import Avatar from '@components/Avatar';
+import ChannelMetadata from '@components/ChannelMetadata';
+import { useChannelQuery } from '@hooks/channel';
+import { useCommunityQuery } from '@hooks/community';
+import { useUserQuery } from '@hooks/user';
 import React from 'react';
+import { useParams } from 'react-router-dom';
 
 const Channel = () => {
-  return <div>Channel</div>;
+  const { communityId, roomId } = useParams();
+  const { communityQuery } = useCommunityQuery(communityId as string);
+  const { channelQuery } = useChannelQuery(roomId as string);
+  const { userQuery } = useUserQuery(channelQuery.data?.managerId as string, {
+    enabled: !!channelQuery.data?.managerId,
+  });
+
+  if (channelQuery.isLoading || communityQuery.isLoading)
+    return <div>loading...</div>;
+
+  return (
+    <div>
+      {channelQuery.data && userQuery.data && communityQuery.data && (
+        <ChannelMetadata
+          profileUrl={communityQuery.data.profileUrl}
+          channelName={channelQuery.data.name}
+          isPrivate={channelQuery.data.isPrivate}
+          createdAt={channelQuery.data.createdAt}
+          managerName={userQuery.data.nickname}
+        />
+      )}
+    </div>
+  );
 };
 
 export default Channel;

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -1,3 +1,9 @@
+const userQueryKey = {
+  all: () => ['users'] as const,
+  detail: (userId: string) =>
+    [...userQueryKey.all(), 'detail', userId] as const,
+};
+
 const directMessageQueryKey = {
   all: ['directMessages'] as const,
   list: () => [...directMessageQueryKey.all] as const,

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -13,6 +13,8 @@ const directMessageQueryKey = {
 const communityQueryKey = {
   all: () => ['communities'] as const,
   createCommunity: () => ['createCommunity'] as const,
+  detail: (communityId: string) =>
+    [...communityQueryKey.all(), 'detail', communityId] as const,
 };
 
 const channelQueryKey = {

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -36,6 +36,7 @@ const queryKeyCreator = {
   directMessage: directMessageQueryKey,
   community: communityQueryKey,
   channel: channelQueryKey,
+  user: userQueryKey,
 } as const;
 
 export default queryKeyCreator;

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -20,7 +20,9 @@ const communityQueryKey = {
 const channelQueryKey = {
   all: () => ['channels'] as const,
   list: (communityId: string) =>
-    [...channelQueryKey.all(), communityId] as const,
+    [...channelQueryKey.all(), 'list', communityId] as const,
+  detail: (channelId: string) =>
+    [...channelQueryKey.all(), 'detail', channelId] as const,
 };
 
 const queryKeyCreator = {

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -1,0 +1,6 @@
+export const formatDate = (str: string) =>
+  new Date(str).toLocaleDateString('ko', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });


### PR DESCRIPTION
## Issues
- #156 

## 🤷‍♂️ Description

- 채널방 시작에서 채널 생성일, 채널 생성한 사람, 채널 이름 등을 표시한다.


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->
- [X] 접속한 채널 이름, 생성일 출력
- [X] 채널 생성한 사용자의 이름 출력

## 📷 Screenshots
![Animation](https://user-images.githubusercontent.com/57662010/204146604-1a995060-23ae-40e4-a293-33fdaeb8aa6e.gif)

 
## 📒 Remarks

- [ ] DM 방의 메타데이터는 고려하지 않았음
- [ ] 최신 메시지부터 불러오므로 처음부터 메타데이터를 띄워주면 안 됨


### API 관련
- 단수/복수
- `id`/`_id`
등등 일관적이지 않은 부분이 있어 현재 postman과 다른 명세 사용하는 API 있음
~~postman에 현재 없는 API도 있음(`/api/communities/:communityId`)~~
`/api/user/communities`에서 가져오기로 수정

### querykey 관련
나중에 리팩토링할 때 querykey도 일관적이게 바꿔야함
특히 cursor를 넘기거나 filter를 넘기는 경우 일관적인 기준이 필요함
