### PR TITLE
[CLIENT] 컨텍스트 메뉴 모달, 커뮤니티 퇴장하기

### DIFF
--- a/client/src/apis/community.ts
+++ b/client/src/apis/community.ts
@@ -75,3 +75,15 @@ export const removeCommunity: RemoveCommunity = (id) => {
 
   return tokenAxios.delete(endPoint).then((response) => response.data.result);
 };
+
+export interface LeaveCommunityResult {
+  message: string;
+}
+
+export type LeaveCommunity = (id: string) => Promise<LeaveCommunityResult>;
+
+export const leaveCommunity: LeaveCommunity = (id) => {
+  const endPoint = `api/community/${id}/me`;
+
+  return tokenAxios.delete(endPoint).then((response) => response.data.result);
+};

--- a/client/src/apis/community.ts
+++ b/client/src/apis/community.ts
@@ -63,3 +63,15 @@ export const createCommunity: CreateCommunity = ({
     .post(endPoint, { name, description, profileUrl })
     .then((response) => response.data.result);
 };
+
+export interface RemoveCommunityResult {
+  message: string;
+}
+
+export type RemoveCommunity = (id: string) => Promise<RemoveCommunityResult>;
+
+export const removeCommunity: RemoveCommunity = (id) => {
+  const endPoint = `api/community/${id}`;
+
+  return tokenAxios.delete(endPoint).then((response) => response.data.result);
+};

--- a/client/src/components/AlertBox/index.tsx
+++ b/client/src/components/AlertBox/index.tsx
@@ -1,0 +1,45 @@
+import Button from '@components/Button';
+import React from 'react';
+
+interface Props {
+  description: string;
+  onCancel: () => void;
+  onSubmit: () => void;
+  disabled?: boolean;
+}
+
+const AlertBox: React.FC<Props> = ({
+  onSubmit,
+  onCancel,
+  description,
+  disabled = false,
+}) => {
+  return (
+    <section className="flex flex-col p-[24px] w-[400px] break-all">
+      <h3 className="sr-only">한번 더 물어보는 알림 메뉴</h3>
+      <header className="mb-[36px] flex-grow">
+        <h4 className="text-s18">{description}</h4>
+      </header>
+      <div className="flex justify-between gap-[24px]">
+        <Button
+          color="error"
+          width="50%"
+          onClick={onCancel}
+          disabled={disabled}
+        >
+          취소
+        </Button>
+        <Button
+          color="success"
+          width="50%"
+          onClick={onSubmit}
+          disabled={disabled}
+        >
+          확인
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default AlertBox;

--- a/client/src/components/CommunityContextMenu/index.tsx
+++ b/client/src/components/CommunityContextMenu/index.tsx
@@ -35,6 +35,9 @@ const CommunityContextMenu: React.FC<Props> = () => {
           </button>
         </li>
       </ul>
+      <div className="px-[12px] mb-[8px]">
+        <div className="w-full h-[1px] bg-line mx-auto"></div>
+      </div>
       <div>
         <button className="flex justify-between items-center w-full text-s16 h-[40px] rounded-xl hover:bg-background px-[12px]">
           <span>커뮤니티에서 나가기</span>

--- a/client/src/components/CommunityContextMenu/index.tsx
+++ b/client/src/components/CommunityContextMenu/index.tsx
@@ -1,0 +1,48 @@
+import type { MouseEventHandler } from 'react';
+
+import {
+  UserPlusIcon,
+  Cog6ToothIcon,
+  ArrowRightOnRectangleIcon,
+} from '@heroicons/react/20/solid';
+import React, { useCallback } from 'react';
+
+interface Props {}
+
+const CommunityContextMenu: React.FC<Props> = () => {
+  const handleRightClickContextMenu: MouseEventHandler<HTMLDivElement> =
+    useCallback((e) => {
+      e.preventDefault();
+    }, []);
+
+  return (
+    <section
+      className="w-[300px] p-[16px]"
+      onContextMenu={handleRightClickContextMenu}
+    >
+      <h3 className="sr-only">커뮤니티 컨텍스트 메뉴</h3>
+      <ul className="">
+        <li className="mb-[8px]">
+          <button className="flex justify-between items-center w-full text-s16 h-[40px] rounded-xl hover:bg-background px-[12px]">
+            <span>커뮤니티에 초대하기</span>
+            <UserPlusIcon className="w-6 h-6 pointer-events-none text-placeholder" />
+          </button>
+        </li>
+        <li className="mb-[8px]">
+          <button className="flex justify-between items-center w-full text-s16 h-[40px] rounded-xl hover:bg-background px-[12px]">
+            <span>커뮤니티 설정하기</span>
+            <Cog6ToothIcon className="w-6 h-6 pointer-events-none text-placeholder" />
+          </button>
+        </li>
+      </ul>
+      <div>
+        <button className="flex justify-between items-center w-full text-s16 h-[40px] rounded-xl hover:bg-background px-[12px]">
+          <span>커뮤니티에서 나가기</span>
+          <ArrowRightOnRectangleIcon className="w-6 h-6 pointer-events-none text-error" />
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default CommunityContextMenu;

--- a/client/src/components/Modals/AlertModal/index.tsx
+++ b/client/src/components/Modals/AlertModal/index.tsx
@@ -1,0 +1,50 @@
+import type { CSSProperties } from 'react';
+
+import AlertBox from '@components/AlertBox';
+import { useRootStore } from '@stores/rootStore';
+import React from 'react';
+import ReactModal from 'react-modal';
+
+const modalOverlayStyle: CSSProperties = {
+  background: 'rgba(0, 0, 0, 0.5)',
+};
+
+const modalContentStyle: CSSProperties = {
+  width: 'max-content',
+  height: 'max-content',
+  borderRadius: 10,
+  padding: 0,
+  inset: '50% 50%',
+  transform: 'translate3d(-50%, -50%, 0)',
+};
+
+const AlertModal = () => {
+  const { isOpen, description, onCancel, onSubmit, disabled } = useRootStore(
+    (state) => state.alertModal,
+  );
+
+  const handleCloseAlertModal = () => {
+    if (!disabled && onCancel) {
+      onCancel();
+    }
+  };
+
+  return (
+    <ReactModal
+      isOpen={isOpen}
+      style={{ content: modalContentStyle, overlay: modalOverlayStyle }}
+      onRequestClose={handleCloseAlertModal}
+    >
+      {onSubmit && onCancel && (
+        <AlertBox
+          description={description}
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+          disabled={disabled}
+        />
+      )}
+    </ReactModal>
+  );
+};
+
+export default AlertModal;

--- a/client/src/components/Modals/ContextMenuModal/index.tsx
+++ b/client/src/components/Modals/ContextMenuModal/index.tsx
@@ -1,0 +1,53 @@
+import type { CSSProperties } from 'react';
+
+import CommunityContextMenu from '@components/CommunityContextMenu';
+import { useRootStore } from '@stores/rootStore';
+import React from 'react';
+import ReactModal from 'react-modal';
+
+const modalOverlayStyle: CSSProperties = {
+  background: 'transparent',
+};
+
+interface Props {}
+
+ReactModal.setAppElement('#root');
+
+const ContextMenuModal: React.FC<Props> = () => {
+  const { x, y, isOpen } = useRootStore((state) => state.contextMenuModal);
+  const closeContextMenuModal = useRootStore(
+    (state) => state.closeContextMenuModal,
+  );
+
+  const modalContentStyle: CSSProperties = {
+    width: 'max-content',
+    height: 'max-content',
+    left: x,
+    top: y,
+    borderRadius: 10,
+    padding: 0,
+  };
+
+  return (
+    <ReactModal
+      isOpen={isOpen}
+      style={{ content: modalContentStyle, overlay: modalOverlayStyle }}
+      onRequestClose={closeContextMenuModal}
+      overlayRef={(ref) => {
+        if (!ref) return;
+        ref.addEventListener('mousedown', (e) => {
+          if (e.target === ref) {
+            closeContextMenuModal();
+          }
+        });
+        ref.addEventListener('contextmenu', (e) => {
+          e.preventDefault();
+        });
+      }}
+    >
+      <CommunityContextMenu />
+    </ReactModal>
+  );
+};
+
+export default ContextMenuModal;

--- a/client/src/components/Modals/ContextMenuModal/index.tsx
+++ b/client/src/components/Modals/ContextMenuModal/index.tsx
@@ -14,7 +14,10 @@ interface Props {}
 ReactModal.setAppElement('#root');
 
 const ContextMenuModal: React.FC<Props> = () => {
-  const { x, y, isOpen } = useRootStore((state) => state.contextMenuModal);
+  const { x, y, isOpen, data, type } = useRootStore(
+    (state) => state.contextMenuModal,
+  );
+
   const closeContextMenuModal = useRootStore(
     (state) => state.closeContextMenuModal,
   );
@@ -27,6 +30,14 @@ const ContextMenuModal: React.FC<Props> = () => {
     borderRadius: 10,
     padding: 0,
   };
+
+  let ContextMenu;
+
+  if (type === 'community')
+    ContextMenu = <CommunityContextMenu community={data} />;
+  else if (type === 'channel')
+    // TODO: ChannelContextMenu로 바꿔야함.
+    ContextMenu = <CommunityContextMenu community={data} />;
 
   return (
     <ReactModal
@@ -45,7 +56,7 @@ const ContextMenuModal: React.FC<Props> = () => {
         });
       }}
     >
-      <CommunityContextMenu />
+      {ContextMenu}
     </ReactModal>
   );
 };

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -3,11 +3,17 @@ import type {
   CreateCommunityRequest,
   GetCommunitiesResult,
   GetCommunityResult,
+  RemoveCommunityResult,
 } from '@apis/community';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
-import { getCommunity, createCommunity, getCommunities } from '@apis/community';
+import {
+  createCommunity,
+  getCommunities,
+  removeCommunity,
+  getCommunity,
+} from '@apis/community';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import queryKeyCreator from 'src/queryKeyCreator';
@@ -48,6 +54,15 @@ export const useCreateCommunityMutation = (
 ) => {
   const key = queryKeyCreator.community.createCommunity();
   const mutation = useMutation(key, createCommunity, { ...options });
+
+  return mutation;
+};
+
+export const useRemoveCommunityMutation = (
+  options?: UseMutationOptions<RemoveCommunityResult, unknown, unknown>,
+) => {
+  const key = queryKeyCreator.community.removeCommunity();
+  const mutation = useMutation(key, removeCommunity, { ...options });
 
   return mutation;
 };

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -32,6 +32,42 @@ export const useCommunitiesQuery = () => {
   return { communitiesQuery: query, invalidateCommunitiesQuery: invalidate };
 };
 
+interface SetCommunities {
+  (
+    callback: (
+      communities?: GetCommunitiesResult,
+    ) => GetCommunitiesResult | undefined,
+  ): void;
+  (communities: GetCommunitiesResult): void;
+}
+
+/**
+ * ### 커뮤니티 쿼리 응답 데이터의 Setter를 반환하는 Custom Hook
+ * - useState hook의 setState처럼 사용하면 됩니다.
+ * ```tsx
+ *   사용 예시
+ *   setComms(
+ *     (prevComms) => prevComms.filter(
+ *       (prevComm) => prevComm.id !== id
+ *     )
+ *   )
+ * ```
+ */
+export const useSetCommunitiesQuery = () => {
+  const queryClient = useQueryClient();
+
+  const key = queryKeyCreator.community.all();
+
+  const setCommunities: SetCommunities = (cb) => {
+    queryClient.setQueryData<GetCommunitiesResult>(key, (communities) => {
+      if (typeof cb === 'function') return cb(communities);
+      return cb;
+    });
+  };
+
+  return setCommunities;
+};
+
 export const useCommunityQuery = (communityId: string) => {
   const queryClient = useQueryClient();
 

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -4,6 +4,7 @@ import type {
   GetCommunitiesResult,
   GetCommunityResult,
   RemoveCommunityResult,
+  LeaveCommunityResult,
 } from '@apis/community';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
@@ -11,6 +12,7 @@ import type { AxiosError } from 'axios';
 import {
   createCommunity,
   getCommunities,
+  leaveCommunity,
   removeCommunity,
   getCommunity,
 } from '@apis/community';
@@ -63,6 +65,15 @@ export const useRemoveCommunityMutation = (
 ) => {
   const key = queryKeyCreator.community.removeCommunity();
   const mutation = useMutation(key, removeCommunity, { ...options });
+
+  return mutation;
+};
+
+export const useLeaveCommunityMutation = (
+  options?: UseMutationOptions<LeaveCommunityResult, unknown, unknown>,
+) => {
+  const key = queryKeyCreator.community.leaveCommunity();
+  const mutation = useMutation(key, leaveCommunity, { ...options });
 
   return mutation;
 };

--- a/client/src/layouts/Gnb/index.tsx
+++ b/client/src/layouts/Gnb/index.tsx
@@ -1,3 +1,4 @@
+import type { CommunitySummary } from '@apis/community';
 import type { MouseEventHandler } from 'react';
 
 import Avatar from '@components/Avatar';
@@ -29,15 +30,15 @@ const Gnb = () => {
   );
 
   const handleRightClickCommunityLink: (
-    id: string,
-  ) => MouseEventHandler<HTMLAnchorElement> = (id: string) => (e) => {
+    community: CommunitySummary,
+  ) => MouseEventHandler<HTMLAnchorElement> = (community) => (e) => {
     e.preventDefault();
 
     openContextMenuModal({
       x: e.clientX,
       y: e.clientY,
       type: 'community',
-      id,
+      data: community,
     });
   };
 
@@ -66,23 +67,27 @@ const Gnb = () => {
           {communitiesQuery.isLoading ? (
             <div>로딩중</div>
           ) : (
-            communitiesQuery.data?.map(({ _id, name, profileUrl }) => (
-              <li key={_id}>
-                <GnbItemContainer isActive={params?.communityId === _id}>
-                  <Link
-                    to={`/communities/${_id}`}
-                    onContextMenu={handleRightClickCommunityLink(_id)}
-                  >
-                    <Avatar
-                      name={name}
-                      size="small"
-                      variant="rectangle"
-                      url={profileUrl}
-                    />
-                  </Link>
-                </GnbItemContainer>
-              </li>
-            ))
+            communitiesQuery.data?.map((community) => {
+              const { _id, name, profileUrl } = community;
+
+              return (
+                <li key={_id}>
+                  <GnbItemContainer isActive={params?.communityId === _id}>
+                    <Link
+                      to={`/communities/${_id}`}
+                      onContextMenu={handleRightClickCommunityLink(community)}
+                    >
+                      <Avatar
+                        name={name}
+                        size="small"
+                        variant="rectangle"
+                        url={profileUrl}
+                      />
+                    </Link>
+                  </GnbItemContainer>
+                </li>
+              );
+            })
           )}
         </ul>
 
@@ -99,6 +104,7 @@ const Gnb = () => {
         </button>
       </div>
 
+      {/* TODO: 툴팁 만들기 */}
       {/* <div className="absolute p-[12px] w-max h-max bg-titleActive text-offWhite left-[100px] top-[20px] z-[9000px]">*/}
       {/* </div>*/}
     </div>

--- a/client/src/layouts/Gnb/index.tsx
+++ b/client/src/layouts/Gnb/index.tsx
@@ -1,23 +1,51 @@
+import type { MouseEventHandler } from 'react';
+
 import Avatar from '@components/Avatar';
 import GnbItemContainer from '@components/GnbItemContainer';
 import { LOGO_IMG_URL } from '@constants/url';
 import { PlusIcon } from '@heroicons/react/24/solid';
 import { useCommunitiesQuery } from '@hooks/community';
 import { useRootStore } from '@stores/rootStore';
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 
 const Gnb = () => {
   const { pathname } = useLocation();
   const params = useParams();
+  const openContextMenuModal = useRootStore(
+    (state) => state.openContextMenuModal,
+  );
 
   const openCreateCommunityModal = useRootStore(
     (state) => state.openCreateCommunityModal,
   );
   const { communitiesQuery } = useCommunitiesQuery();
 
+  const handleRightClickGnb: MouseEventHandler<HTMLDivElement> = useCallback(
+    (e) => {
+      e.preventDefault();
+    },
+    [],
+  );
+
+  const handleRightClickCommunityLink: (
+    id: string,
+  ) => MouseEventHandler<HTMLAnchorElement> = (id: string) => (e) => {
+    e.preventDefault();
+
+    openContextMenuModal({
+      x: e.clientX,
+      y: e.clientY,
+      type: 'community',
+      id,
+    });
+  };
+
   return (
-    <div className="flex min-w-[80px] w-[80px] h-full bg-background border-r border-line z-[100px]">
+    <div
+      className="flex min-w-[80px] w-[80px] h-full bg-background border-r border-line z-[100px]"
+      onContextMenu={handleRightClickGnb}
+    >
       <div className="flex flex-col justify-start items-center w-full pt-[16px] overflow-auto no-display-scrollbar pb-[30vh]">
         <div className="w-full">
           <GnbItemContainer isActive={pathname === '/dms'}>
@@ -39,19 +67,21 @@ const Gnb = () => {
             <div>로딩중</div>
           ) : (
             communitiesQuery.data?.map(({ _id, name, profileUrl }) => (
-              <GnbItemContainer
-                key={_id}
-                isActive={params?.communityId === _id}
-              >
-                <Link to={`/communities/${_id}`}>
-                  <Avatar
-                    name={name}
-                    size="small"
-                    variant="rectangle"
-                    url={profileUrl}
-                  />
-                </Link>
-              </GnbItemContainer>
+              <li key={_id}>
+                <GnbItemContainer isActive={params?.communityId === _id}>
+                  <Link
+                    to={`/communities/${_id}`}
+                    onContextMenu={handleRightClickCommunityLink(_id)}
+                  >
+                    <Avatar
+                      name={name}
+                      size="small"
+                      variant="rectangle"
+                      url={profileUrl}
+                    />
+                  </Link>
+                </GnbItemContainer>
+              </li>
             ))
           )}
         </ul>
@@ -68,6 +98,9 @@ const Gnb = () => {
           </Avatar>
         </button>
       </div>
+
+      {/* <div className="absolute p-[12px] w-max h-max bg-titleActive text-offWhite left-[100px] top-[20px] z-[9000px]">*/}
+      {/* </div>*/}
     </div>
   );
 };

--- a/client/src/mocks/handlers/Community.js
+++ b/client/src/mocks/handlers/Community.js
@@ -6,6 +6,7 @@ import {
   createErrorContext,
   createSuccessContext,
 } from '../utils/createContext';
+import { colorLog } from '../utils/logging';
 
 const BASE_URL = `${API_URL}/api`;
 
@@ -87,4 +88,25 @@ const CreateCommunity = rest.post(
   },
 );
 
-export default [GetCommunities, GetCommunity, CreateCommunity];
+export const LeaveCommunity = rest.delete(
+  `${BASE_URL}/community/:id/me`,
+  (req, res, ctx) => {
+    const { id } = req.params;
+
+    colorLog(`커뮤니티 ID ${id}에서 퇴장하였습니다.`);
+
+    const ERROR = false;
+
+    const successResponse = res(
+      ...createSuccessContext(ctx, 201, 500, {
+        message: '커뮤니티 퇴장 성공~',
+      }),
+    );
+
+    const errorResponse = res(...createErrorContext(ctx));
+
+    return ERROR ? errorResponse : successResponse;
+  },
+);
+
+export default [GetCommunities, GetCommunity, CreateCommunity, LeaveCommunity];

--- a/client/src/mocks/handlers/Community.js
+++ b/client/src/mocks/handlers/Community.js
@@ -93,17 +93,23 @@ export const LeaveCommunity = rest.delete(
   (req, res, ctx) => {
     const { id } = req.params;
 
-    colorLog(`커뮤니티 ID ${id}에서 퇴장하였습니다.`);
-
     const ERROR = false;
+    const successDelay = 500;
 
     const successResponse = res(
-      ...createSuccessContext(ctx, 201, 500, {
+      ...createSuccessContext(ctx, 201, successDelay, {
         message: '커뮤니티 퇴장 성공~',
       }),
     );
 
     const errorResponse = res(...createErrorContext(ctx));
+
+    if (!ERROR) {
+      setTimeout(
+        () => colorLog(`커뮤니티 ID ${id}에서 퇴장하였습니다.`),
+        successDelay,
+      );
+    }
 
     return ERROR ? errorResponse : successResponse;
   },

--- a/client/src/mocks/handlers/Community.js
+++ b/client/src/mocks/handlers/Community.js
@@ -105,10 +105,12 @@ export const LeaveCommunity = rest.delete(
     const errorResponse = res(...createErrorContext(ctx));
 
     if (!ERROR) {
-      setTimeout(
-        () => colorLog(`커뮤니티 ID ${id}에서 퇴장하였습니다.`),
-        successDelay,
-      );
+      setTimeout(() => {
+        colorLog(`커뮤니티 ID ${id}에서 퇴장하였습니다.`);
+        const targetIdx = communities.findIndex(({ _id }) => _id === id);
+
+        communities.splice(targetIdx, 1);
+      }, successDelay);
     }
 
     return ERROR ? errorResponse : successResponse;

--- a/client/src/mocks/utils/logging.js
+++ b/client/src/mocks/utils/logging.js
@@ -1,0 +1,4 @@
+export const colorLog = (message, textColor) => {
+  textColor = textColor ? `color: ${textColor}` : `color: #bada55`;
+  console.log(`%c${message}`, textColor);
+};

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -1,3 +1,4 @@
+import ContextMenuModal from '@components/Modals/ContextMenuModal';
 import CreateCommunityModal from '@components/Modals/CreateCommunityModal';
 import Gnb from '@layouts/Gnb';
 import Sidebar from '@layouts/Sidebar';
@@ -11,6 +12,7 @@ const Home = () => {
       <Sidebar />
       <Outlet />
       <CreateCommunityModal />
+      <ContextMenuModal />
     </div>
   );
 };

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -1,3 +1,4 @@
+import AlertModal from '@components/Modals/AlertModal';
 import ContextMenuModal from '@components/Modals/ContextMenuModal';
 import CreateCommunityModal from '@components/Modals/CreateCommunityModal';
 import Gnb from '@layouts/Gnb';
@@ -13,6 +14,7 @@ const Home = () => {
       <Outlet />
       <CreateCommunityModal />
       <ContextMenuModal />
+      <AlertModal />
     </div>
   );
 };

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -16,6 +16,7 @@ const communityQueryKey = {
   removeCommunity: () => ['removeCommunity'] as const,
   detail: (communityId: string) =>
     [...communityQueryKey.all(), 'detail', communityId] as const,
+  leaveCommunity: () => ['leaveCommunity'] as const,
 };
 
 const channelQueryKey = {

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -13,6 +13,7 @@ const directMessageQueryKey = {
 const communityQueryKey = {
   all: () => ['communities'] as const,
   createCommunity: () => ['createCommunity'] as const,
+  removeCommunity: () => ['removeCommunity'] as const,
   detail: (communityId: string) =>
     [...communityQueryKey.all(), 'detail', communityId] as const,
 };

--- a/client/src/stores/alertModalSlice.ts
+++ b/client/src/stores/alertModalSlice.ts
@@ -5,6 +5,7 @@ import { immer } from 'zustand/middleware/immer';
 export interface AlertModal {
   description: string;
   isOpen: boolean;
+  disabled: boolean;
   onCancel: (() => void) | null;
   onSubmit: (() => void) | null;
 }
@@ -13,12 +14,14 @@ type OpenAlertModal = ({
   description,
   onCancel,
   onSubmit,
-}: Omit<AlertModal, 'isOpen'>) => void;
+}: Omit<AlertModal, 'isOpen' | 'disabled'>) => void;
 
 export interface AlertModalSlice {
   alertModal: AlertModal;
   openAlertModal: OpenAlertModal;
   closeAlertModal: () => void;
+  disableAlertModal: () => void;
+  enableAlertModal: () => void;
 }
 
 const initialAlertModalValue = {
@@ -26,6 +29,7 @@ const initialAlertModalValue = {
   description: '',
   onSubmit: null,
   onCancel: null,
+  disabled: false,
 };
 
 export const alertModalSlice: StateCreator<
@@ -42,10 +46,19 @@ export const alertModalSlice: StateCreator<
         onCancel,
         onSubmit,
         isOpen: true,
+        disabled: state.alertModal.disabled,
       };
     }),
   closeAlertModal: () =>
     set((state) => {
       state.alertModal = initialAlertModalValue;
+    }),
+  disableAlertModal: () =>
+    set((state) => {
+      state.alertModal.disabled = true;
+    }),
+  enableAlertModal: () =>
+    set((state) => {
+      state.alertModal.disabled = false;
     }),
 }));

--- a/client/src/stores/alertModalSlice.ts
+++ b/client/src/stores/alertModalSlice.ts
@@ -1,0 +1,51 @@
+import type { StateCreator } from 'zustand';
+
+import { immer } from 'zustand/middleware/immer';
+
+export interface AlertModal {
+  description: string;
+  isOpen: boolean;
+  onCancel: (() => void) | null;
+  onSubmit: (() => void) | null;
+}
+
+type OpenAlertModal = ({
+  description,
+  onCancel,
+  onSubmit,
+}: Omit<AlertModal, 'isOpen'>) => void;
+
+export interface AlertModalSlice {
+  alertModal: AlertModal;
+  openAlertModal: OpenAlertModal;
+  closeAlertModal: () => void;
+}
+
+const initialAlertModalValue = {
+  isOpen: false,
+  description: '',
+  onSubmit: null,
+  onCancel: null,
+};
+
+export const alertModalSlice: StateCreator<
+  AlertModalSlice,
+  [],
+  [['zustand/immer', never], ...[]],
+  AlertModalSlice
+> = immer((set) => ({
+  alertModal: initialAlertModalValue,
+  openAlertModal: ({ description, onCancel, onSubmit }) =>
+    set((state) => {
+      state.alertModal = {
+        description,
+        onCancel,
+        onSubmit,
+        isOpen: true,
+      };
+    }),
+  closeAlertModal: () =>
+    set((state) => {
+      state.alertModal = initialAlertModalValue;
+    }),
+}));

--- a/client/src/stores/contextMenuModalSlice.ts
+++ b/client/src/stores/contextMenuModalSlice.ts
@@ -1,22 +1,40 @@
+import type { CommunitySummary } from '@apis/community';
 import type { StateCreator } from 'zustand';
 
 import { immer } from 'zustand/middleware/immer';
 
-export type ContextMenuType = 'community' | 'channel' | null;
-
-export interface ContextMenuModal {
-  id: string | null;
+export interface ContextMenuModalBase {
   x: number;
   y: number;
-  type: ContextMenuType;
   isOpen: boolean;
 }
+
+export interface CommunityContextMenuModal extends ContextMenuModalBase {
+  data: CommunitySummary;
+  type: 'community';
+}
+
+export interface ChannelContextMenuModal extends ContextMenuModalBase {
+  data: CommunitySummary; // TODO: 채널 모달 타입으로 바꿔야 함.
+  type: 'channel';
+}
+
+export interface InitialContextMenuModal extends ContextMenuModalBase {
+  data: null;
+  type: null;
+}
+
+export type ContextMenuModal =
+  | InitialContextMenuModal
+  | ChannelContextMenuModal
+  | CommunityContextMenuModal;
+
 export type OpenContextMenuModal = ({
-  id,
+  data,
   x,
   y,
   type,
-}: Omit<ContextMenuModal, 'isOpen'>) => void;
+}: Omit<CommunityContextMenuModal | ChannelContextMenuModal, 'isOpen'>) => void;
 
 export interface ContextMenuModalSlice {
   contextMenuModal: ContextMenuModal;
@@ -25,12 +43,12 @@ export interface ContextMenuModalSlice {
 }
 
 const initialContextMenuModalValue = {
-  id: null,
+  data: null,
   type: null,
   isOpen: false,
   x: 0,
   y: 0,
-};
+} as const;
 
 export const contextMenuModalSlice: StateCreator<
   ContextMenuModalSlice,
@@ -39,10 +57,10 @@ export const contextMenuModalSlice: StateCreator<
   ContextMenuModalSlice
 > = immer((set) => ({
   contextMenuModal: initialContextMenuModalValue,
-  openContextMenuModal: ({ id, x, y, type }) =>
+  openContextMenuModal: ({ data, x, y, type }) =>
     set((state) => {
       state.contextMenuModal = {
-        id,
+        data,
         x,
         y,
         type,

--- a/client/src/stores/contextMenuModalSlice.ts
+++ b/client/src/stores/contextMenuModalSlice.ts
@@ -1,0 +1,56 @@
+import type { StateCreator } from 'zustand';
+
+import { immer } from 'zustand/middleware/immer';
+
+export type ContextMenuType = 'community' | 'channel' | null;
+
+export interface ContextMenuModal {
+  id: string | null;
+  x: number;
+  y: number;
+  type: ContextMenuType;
+  isOpen: boolean;
+}
+export type OpenContextMenuModal = ({
+  id,
+  x,
+  y,
+  type,
+}: Omit<ContextMenuModal, 'isOpen'>) => void;
+
+export interface ContextMenuModalSlice {
+  contextMenuModal: ContextMenuModal;
+  openContextMenuModal: OpenContextMenuModal;
+  closeContextMenuModal: () => void;
+}
+
+const initialContextMenuModalValue = {
+  id: null,
+  type: null,
+  isOpen: false,
+  x: 0,
+  y: 0,
+};
+
+export const contextMenuModalSlice: StateCreator<
+  ContextMenuModalSlice,
+  [],
+  [['zustand/immer', never], ...[]],
+  ContextMenuModalSlice
+> = immer((set) => ({
+  contextMenuModal: initialContextMenuModalValue,
+  openContextMenuModal: ({ id, x, y, type }) =>
+    set((state) => {
+      state.contextMenuModal = {
+        id,
+        x,
+        y,
+        type,
+        isOpen: true,
+      };
+    }),
+  closeContextMenuModal: () =>
+    set((state) => {
+      state.contextMenuModal = initialContextMenuModalValue;
+    }),
+}));

--- a/client/src/stores/rootStore.ts
+++ b/client/src/stores/rootStore.ts
@@ -1,14 +1,16 @@
+import type { ContextMenuModalSlice } from '@stores/contextMenuModalSlice';
 import type { CreateCommunityModalSlice } from '@stores/createCommunityModalSlice';
 
+import { contextMenuModalSlice } from '@stores/contextMenuModalSlice';
+import { createCommunityModalSlice } from '@stores/createCommunityModalSlice';
 import store from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-import { createCommunityModalSlice } from './createCommunityModalSlice';
-
-export type Store = CreateCommunityModalSlice;
+export type Store = CreateCommunityModalSlice & ContextMenuModalSlice;
 
 export const useRootStore = store<Store>()(
   devtools((...a) => ({
     ...createCommunityModalSlice(...a),
+    ...contextMenuModalSlice(...a),
   })),
 );

--- a/client/src/stores/rootStore.ts
+++ b/client/src/stores/rootStore.ts
@@ -1,16 +1,21 @@
+import type { AlertModalSlice } from '@stores/alertModalSlice';
 import type { ContextMenuModalSlice } from '@stores/contextMenuModalSlice';
 import type { CreateCommunityModalSlice } from '@stores/createCommunityModalSlice';
 
+import { alertModalSlice } from '@stores/alertModalSlice';
 import { contextMenuModalSlice } from '@stores/contextMenuModalSlice';
 import { createCommunityModalSlice } from '@stores/createCommunityModalSlice';
 import store from 'zustand';
 import { devtools } from 'zustand/middleware';
 
-export type Store = CreateCommunityModalSlice & ContextMenuModalSlice;
+export type Store = CreateCommunityModalSlice &
+  ContextMenuModalSlice &
+  AlertModalSlice;
 
 export const useRootStore = store<Store>()(
   devtools((...a) => ({
     ...createCommunityModalSlice(...a),
     ...contextMenuModalSlice(...a),
+    ...alertModalSlice(...a),
   })),
 );


### PR DESCRIPTION
## Issues
- #157 
- #162 

<!-- 어떤 이슈와 관련된 PR인지 적어주세요! 이슈와 PR을 연결하려면 반드시 적어야 합니다. -->
<!-- 필요하다면 여러 이슈를 적는 것도 가능할지도? -->
<!-- - #IssueNumber 로 타이핑하면 자동완성되는 문장을 사용해주세요. -->
<!-- 예시) - #1 -->

## 🤷‍♂️ Description

커뮤니티 모달과 커뮤니티 퇴장 기능까지 구현하였습니다. 원래는 이 둘을 나눠서 PR 올리려고 했는데, 퇴장 기능 구현하면서 모달에 전달하는 상태 타입들이 바뀌어서 한번에 올립니다.

커뮤니티 퇴장을 삭제랑 헷갈려서 커뮤니티 삭제 `api`까지 넣었습니다. (기능은 구현 X)

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 컨텍스트 메뉴 모달 상태 정의, 마크업
- [X] Alert 모달 상태 정의, 마크업
- [X] 커뮤니티 퇴장 기능


## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
### 퇴장하려는 커뮤니티에 접속하지 않은 경우
![커뮤니티 퇴장](https://user-images.githubusercontent.com/79135734/204153496-2ccd8456-5473-44d6-ae1d-6078d4046296.gif)

### 퇴장하려는 커뮤니티에 접속해있는 경우
![커뮤니티 삭제2](https://user-images.githubusercontent.com/79135734/204153514-0b3d34aa-7aa6-46c3-bb51-861f41027d26.gif)

 
## 📒 Remarks

참고로, Mock API로 테스트할 때는 커뮤니티 퇴장 후, 모킹 데이터인 `communities`배열을 업데이트하지 않아서 `refetch`되면 원 상태로 돌아오긴 합니다. 

선언을 `let`으로 바꾸고 `filter`메서드로 제거하려고 했었는데, 런타임에 자꾸 오류가 뜨더라구요.



<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
