### PR TITLE
[Server/channel update last read] 마지막 채널 접속시간 업데이트 API

### DIFF
--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -109,7 +109,12 @@ export class ChannelController {
   @UseGuards(JwtAccessGuard)
   async updateLastRead(@Body() updateLastReaddto: UpdateLastReadDto, @Req() req: any) {
     const user_id = req.user._id;
-    await this.channelService.updateLastRead({ ...updateLastReaddto, user_id });
-    return responseForm(200, { message: 'Last Read 업데이트 성공' });
+    try {
+      await this.channelService.updateLastRead({ ...updateLastReaddto, user_id });
+      return responseForm(200, { message: 'Last Read 업데이트 성공' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
   }
 }

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -14,7 +14,12 @@ import {
 import { responseForm } from '@utils/responseForm';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ChannelService } from '@channel/channel.service';
-import { CreateChannelDto, InviteChannelDto, ModifyChannelDto } from '@channel/dto';
+import {
+  CreateChannelDto,
+  InviteChannelDto,
+  ModifyChannelDto,
+  UpdateLastReadDto,
+} from '@channel/dto';
 import { JwtAccessGuard } from '@auth/guard';
 
 @Controller('api/channel')
@@ -98,5 +103,13 @@ export class ChannelController {
       this.logger.error(JSON.stringify(error.response));
       throw error;
     }
+  }
+
+  @Post('update/lastRead')
+  @UseGuards(JwtAccessGuard)
+  async updateLastRead(@Body() updateLastReaddto: UpdateLastReadDto, @Req() req: any) {
+    const user_id = req.user._id;
+    await this.channelService.updateLastRead({ ...updateLastReaddto, user_id });
+    return responseForm(200, { message: 'Last Read 업데이트 성공' });
   }
 }

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -7,6 +7,7 @@ import {
   DeleteChannelDto,
   InviteChannelDto,
   ModifyChannelDto,
+  UpdateLastReadDto,
 } from '@channel/dto';
 import { ExitChannelDto } from '@channel/dto/exit-channel.dto';
 import { getChannelBasicInfo, getChannelToUserForm } from '@channel/helper';
@@ -129,5 +130,14 @@ export class ChannelService {
     const { community_id, channel_id, inviteUserList } = inviteChannelDto;
     // 유저 도큐먼트의 커뮤니티:채널 필드 업데이트
     await this.addUserToChannel(community_id, channel_id, inviteUserList);
+  }
+
+  async updateLastRead(updateLastReadDto: UpdateLastReadDto) {
+    const { community_id, channel_id, user_id } = updateLastReadDto;
+    // 유저 도큐먼트의 커뮤니티: 채널 필드 업데이트
+    await this.userRepository.updateObject(
+      { _id: user_id },
+      getChannelToUserForm(community_id, channel_id),
+    );
   }
 }

--- a/server/apps/api/src/channel/dto/index.ts
+++ b/server/apps/api/src/channel/dto/index.ts
@@ -3,3 +3,4 @@ export * from './modify-channel.dto';
 export * from './exit-channel.dto';
 export * from './delete-channel.dto';
 export * from './invite-channel.dto';
+export * from './update-last-read.dto';

--- a/server/apps/api/src/channel/dto/update-last-read.dto.ts
+++ b/server/apps/api/src/channel/dto/update-last-read.dto.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+@Injectable()
+export class UpdateLastReadDto {
+  @IsString()
+  @IsOptional()
+  user_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  community_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  channel_id: string;
+}


### PR DESCRIPTION
## Issues
- #177 

## 🤷‍♂️ Description

안읽은 메세지 구현을 위한 API
다른 채널로 이동 시, 이전 채널의 마지막 접속시간 업데이트


## 📝 Primary Commits

- [x]  channel.dto
    
    ```tsx
    community_id: NotEmpty, String
    channel_id: NotEmpty, String
    ```
- [x]  channel.controller
    - api/channel/update/lastRead
- [x]  channel.service
    - user 도큐먼트의 community:channel 필드 현재시간으로 업데이트

## 📷 Screenshots
- 업데이트 성공시
<img width="419" alt="스크린샷 2022-11-28 오후 7 46 06" src="https://user-images.githubusercontent.com/72093196/204258743-dd92b1cf-e6ed-4e06-b12a-7b06eb501adc.png">
