### PR TITLE
[CLIENT] 커뮤니티 초대

### DIFF
--- a/client/src/apis/channel.ts
+++ b/client/src/apis/channel.ts
@@ -1,9 +1,7 @@
 import type { SuccessResponse } from '@@types/apis/response';
-import type { User } from '@apis/user';
+import type { UserUID } from '@apis/user';
 
 import { tokenAxios } from '@utils/axios';
-
-type UserUID = User['_id'];
 
 export interface JoinedChannel {
   _id: string;

--- a/client/src/apis/community.ts
+++ b/client/src/apis/community.ts
@@ -1,6 +1,6 @@
 import type { SuccessResponse } from '@@types/apis/response';
 import type { JoinedChannel } from '@apis/channel';
-import type { User } from '@apis/user';
+import type { User, UserUID } from '@apis/user';
 
 import { tokenAxios } from '@utils/axios';
 
@@ -88,4 +88,25 @@ export const leaveCommunity: LeaveCommunity = (id) => {
   const endPoint = `api/community/${id}/me`;
 
   return tokenAxios.delete(endPoint).then((response) => response.data.result);
+};
+
+export interface InviteCommunityRequest {
+  communityId: string;
+  userIds: Array<UserUID>;
+}
+
+export interface InviteCommunityResult {
+  message: string;
+}
+
+export type InviteCommunity = (
+  fields: InviteCommunityRequest,
+) => Promise<InviteCommunityResult>;
+
+export const inviteCommunity: InviteCommunity = ({ communityId, userIds }) => {
+  const endPoint = `api/community/${communityId}/participants`;
+
+  return tokenAxios
+    .post<SuccessResponse<InviteCommunityResult>>(endPoint, { users: userIds })
+    .then((response) => response.data.result);
 };

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -15,6 +15,8 @@ export interface User {
   description: string;
 }
 
+export type UserUID = User['_id'];
+
 export type MyInfoResult = User;
 
 type GetMyInfo = () => Promise<MyInfoResult>;

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -67,10 +67,27 @@ export type GetUserResult = User;
 export type GetUserResponse = SuccessResponse<GetUserResult>;
 export type GetUser = (userId: string) => Promise<GetUserResult>;
 
-export const getUser: GetUser = (userId: string) => {
+export const getUser: GetUser = (userId) => {
   const endPoint = `${API_URL}/api/users/${userId}`;
 
   return tokenAxios
     .get<GetUserResponse>(endPoint)
     .then((response) => response.data.result);
+};
+
+export interface GetCommunityUsersResult {
+  users: User[];
+}
+
+export type GetCommunityUsersResponse =
+  SuccessResponse<GetCommunityUsersResult>;
+
+export type GetCommunityUsers = (communityId: string) => Promise<User[]>;
+
+export const getCommunityUsers: GetCommunityUsers = (communityId) => {
+  const endPoint = `${API_URL}/api/community/${communityId}/participants`;
+
+  return tokenAxios
+    .get<GetCommunityUsersResponse>(endPoint)
+    .then((response) => response.data.result.users);
 };

--- a/client/src/components/AlertBox/index.tsx
+++ b/client/src/components/AlertBox/index.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import Button from '@components/Button';
 import React from 'react';
 
@@ -8,7 +10,7 @@ interface Props {
   disabled?: boolean;
 }
 
-const AlertBox: React.FC<Props> = ({
+const AlertBox: FC<Props> = ({
   onSubmit,
   onCancel,
   description,

--- a/client/src/components/AuthInput/index.tsx
+++ b/client/src/components/AuthInput/index.tsx
@@ -2,6 +2,7 @@ import type {
   ChangeEventHandler,
   ComponentPropsWithRef,
   HTMLInputTypeAttribute,
+  FC,
 } from 'react';
 
 import cn from 'classnames';
@@ -15,7 +16,7 @@ interface Props extends ComponentPropsWithRef<'input'> {
   placeholder?: string;
 }
 
-const AuthInput: React.FC<Props> = forwardRef(
+const AuthInput: FC<Props> = forwardRef(
   (
     {
       type = 'text',

--- a/client/src/components/Avatar/index.tsx
+++ b/client/src/components/Avatar/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, FC } from 'react';
 
 import React, { memo } from 'react';
 
@@ -34,7 +34,7 @@ const getFirstLetter = (str: string) => {
   return firstLetter;
 };
 
-const Avatar: React.FC<AvatarProps> = ({
+const Avatar: FC<AvatarProps> = ({
   name,
   url,
   size,

--- a/client/src/components/Badge/index.tsx
+++ b/client/src/components/Badge/index.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import React from 'react';
 
 interface BadgeProps {
@@ -17,7 +19,7 @@ const background = {
   default: 'bg-label',
 };
 
-const Badge: React.FC<BadgeProps> = ({
+const Badge: FC<BadgeProps> = ({
   children,
   size = 'small',
   color = 'default',

--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentPropsWithoutRef } from 'react';
+import type { FC, ReactNode, ComponentPropsWithoutRef } from 'react';
 
 import React, { useMemo } from 'react';
 
@@ -73,7 +73,7 @@ export interface Props extends ComponentPropsWithoutRef<'button'> {
   color?: ButtonColor;
 }
 
-const Button: React.FC<Props> = ({
+const Button: FC<Props> = ({
   children,
   outlined = false,
   size = 'sm',

--- a/client/src/components/ChannelItem/index.tsx
+++ b/client/src/components/ChannelItem/index.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import { HashtagIcon, LockClosedIcon } from '@heroicons/react/20/solid';
 import React, { memo } from 'react';
 
@@ -7,11 +9,7 @@ interface Props {
   className?: string;
 }
 
-const ChannelItem: React.FC<Props> = ({
-  name,
-  isPrivate = true,
-  className = '',
-}) => {
+const ChannelItem: FC<Props> = ({ name, isPrivate = true, className = '' }) => {
   return (
     <div className={`flex items-center gap-[5px] select-none ${className}`}>
       <div>

--- a/client/src/components/CommunityContextMenu/index.tsx
+++ b/client/src/components/CommunityContextMenu/index.tsx
@@ -1,6 +1,6 @@
 import type { CommunitySummary } from '@apis/community';
 import type { Store } from '@stores/rootStore';
-import type { MouseEventHandler } from 'react';
+import type { MouseEventHandler, FC } from 'react';
 
 import CommunityInviteBox from '@components/CommunityInviteBox';
 import defaultErrorHandler from '@errors/defaultErrorHandler';
@@ -22,7 +22,7 @@ interface Props {
   community: CommunitySummary;
 }
 
-const CommunityContextMenu: React.FC<Props> = ({ community }) => {
+const CommunityContextMenu: FC<Props> = ({ community }) => {
   const params = useParams();
   const navigate = useNavigate();
   const handleRightClickContextMenu: MouseEventHandler<HTMLDivElement> =

--- a/client/src/components/CommunityContextMenu/index.tsx
+++ b/client/src/components/CommunityContextMenu/index.tsx
@@ -1,6 +1,8 @@
 import type { CommunitySummary } from '@apis/community';
+import type { Store } from '@stores/rootStore';
 import type { MouseEventHandler } from 'react';
 
+import CommunityInviteBox from '@components/CommunityInviteBox';
 import defaultErrorHandler from '@errors/defaultErrorHandler';
 import {
   UserPlusIcon,
@@ -11,6 +13,7 @@ import {
   useLeaveCommunityMutation,
   useSetCommunitiesQuery,
 } from '@hooks/community';
+import { useCommunityUsersQuery } from '@hooks/user';
 import { useRootStore } from '@stores/rootStore';
 import React, { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -30,10 +33,14 @@ const CommunityContextMenu: React.FC<Props> = ({ community }) => {
   const leaveCommunityMutation = useLeaveCommunityMutation();
   const setCommunities = useSetCommunitiesQuery();
 
+  useCommunityUsersQuery(community._id);
+
   const openAlertModal = useRootStore((state) => state.openAlertModal);
   const closeAlertModal = useRootStore((state) => state.closeAlertModal);
   const disableAlertModal = useRootStore((state) => state.disableAlertModal);
   const enableAlertModal = useRootStore((state) => state.enableAlertModal);
+
+  const openCommonModal = useRootStore((state: Store) => state.openCommonModal);
 
   const closeContextMenuModal = useRootStore(
     (state) => state.closeContextMenuModal,
@@ -72,6 +79,18 @@ const CommunityContextMenu: React.FC<Props> = ({ community }) => {
     });
   };
 
+  const handleClickUserInviteButton = () => {
+    closeContextMenuModal();
+    openCommonModal({
+      content: <CommunityInviteBox />,
+      data: { communityId: community._id },
+      overlayBackground: 'black',
+      x: '50%',
+      y: '50%',
+      transform: 'translate3d(-50%, -50%, 0)',
+    });
+  };
+
   return (
     <section
       className="w-[300px] p-[16px]"
@@ -80,7 +99,10 @@ const CommunityContextMenu: React.FC<Props> = ({ community }) => {
       <h3 className="sr-only">커뮤니티 컨텍스트 메뉴</h3>
       <ul className="">
         <li className="mb-[8px]">
-          <button className="flex justify-between items-center w-full text-s16 h-[40px] rounded-xl hover:bg-background px-[12px]">
+          <button
+            className="flex justify-between items-center w-full text-s16 h-[40px] rounded-xl hover:bg-background px-[12px]"
+            onClick={handleClickUserInviteButton}
+          >
             <span>커뮤니티에 초대하기</span>
             <UserPlusIcon className="w-6 h-6 pointer-events-none text-placeholder" />
           </button>

--- a/client/src/components/CommunityInviteBox/index.tsx
+++ b/client/src/components/CommunityInviteBox/index.tsx
@@ -1,0 +1,16 @@
+import CommunityInviteUserSearchResultBox from '@components/CommunityInviteUserSearchResultBox';
+import UserSearch from '@layouts/UserSearch';
+import React from 'react';
+
+/**
+ * 커뮤니티 초대 모달 컨텐츠 영역을 나타내는 컴포넌트입니다.
+ */
+const CommunityInviteBox: React.FC = () => {
+  return (
+    <div className="bg-offWhite min-w-[500px] w-[50vw] h-[70vh]">
+      <UserSearch Variant={CommunityInviteUserSearchResultBox} />
+    </div>
+  );
+};
+
+export default CommunityInviteBox;

--- a/client/src/components/CommunityInviteBox/index.tsx
+++ b/client/src/components/CommunityInviteBox/index.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import CommunityInviteUserSearchResultBox from '@components/CommunityInviteUserSearchResultBox';
 import UserSearch from '@layouts/UserSearch';
 import React from 'react';
@@ -5,7 +7,7 @@ import React from 'react';
 /**
  * 커뮤니티 초대 모달 컨텐츠 영역을 나타내는 컴포넌트입니다.
  */
-const CommunityInviteBox: React.FC = () => {
+const CommunityInviteBox: FC = () => {
   return (
     <div className="bg-offWhite min-w-[500px] w-[50vw] h-[70vh]">
       <UserSearch Variant={CommunityInviteUserSearchResultBox} />

--- a/client/src/components/CommunityInviteUserSearchResultBox/index.tsx
+++ b/client/src/components/CommunityInviteUserSearchResultBox/index.tsx
@@ -46,9 +46,10 @@ const CommunityInviteUserSearchResultBox: React.FC<Props> = ({
 
       inviteCommunityMutation
         .mutateAsync({ communityId, userIds })
-        .then(async () => {
-          await invalidateCommunityUsersQuery();
-          toast.success('커뮤니티로 초대 성공!');
+        .then(() => {
+          invalidateCommunityUsersQuery().finally(() => {
+            toast.success('커뮤니티로 초대 성공!');
+          });
         })
         .catch((_error) => defaultErrorHandler(_error));
     };

--- a/client/src/components/CommunityInviteUserSearchResultBox/index.tsx
+++ b/client/src/components/CommunityInviteUserSearchResultBox/index.tsx
@@ -1,5 +1,5 @@
 import type { User, UserUID } from '@apis/user';
-import type { MouseEventHandler } from 'react';
+import type { MouseEventHandler, FC } from 'react';
 
 import ErrorMessage from '@components/ErrorMessage';
 import UserItem from '@components/UserItem';
@@ -21,7 +21,7 @@ interface Props {
   error: unknown;
 }
 
-const CommunityInviteUserSearchResultBox: React.FC<Props> = ({
+const CommunityInviteUserSearchResultBox: FC<Props> = ({
   users,
   isLoading,
   error,

--- a/client/src/components/CommunityInviteUserSearchResultBox/index.tsx
+++ b/client/src/components/CommunityInviteUserSearchResultBox/index.tsx
@@ -1,0 +1,98 @@
+import type { User } from '@apis/user';
+
+import ErrorMessage from '@components/ErrorMessage';
+import UserItem from '@components/UserItem';
+import { UserPlusIcon } from '@heroicons/react/20/solid';
+import { useCommunityUsersQuery } from '@hooks/user';
+import { useRootStore } from '@stores/rootStore';
+import React from 'react';
+import Scrollbars from 'react-custom-scrollbars-2';
+
+interface Props {
+  users?: User[];
+  isLoading: boolean;
+  error: unknown;
+}
+
+const CommunityInviteUserSearchResultBox: React.FC<Props> = ({
+  users,
+  isLoading,
+  error,
+}) => {
+  const data = useRootStore(
+    (state) => state.commonModal.data as { communityId: string },
+  );
+
+  const { communityUsersQuery } = useCommunityUsersQuery(data.communityId);
+
+  if (!communityUsersQuery?.data) {
+    return <div />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="w-full h-full flex justify-center items-center">
+        로딩중...
+      </div>
+    );
+  }
+
+  if (!users) {
+    return (
+      <div className="w-full h-full flex justify-center items-center">
+        검색어를 입력하세요
+      </div>
+    );
+  }
+
+  if (!users.length) {
+    return (
+      <div className="w-full h-full flex justify-center items-center">
+        검색 결과가 없습니다.
+      </div>
+    );
+  }
+
+  if (error || communityUsersQuery.error) {
+    return (
+      <ErrorMessage size="lg">
+        사용자를 불러오는데 에러가 발생했습니다.
+      </ErrorMessage>
+    );
+  }
+
+  return (
+    <Scrollbars>
+      <ul>
+        {users.map((user) => {
+          /** 이미 커뮤니티에 포함된 사용자라면, true */
+          const disabled = communityUsersQuery.data.some(
+            ({ _id }) => _id === user._id,
+          );
+
+          return (
+            <UserItem
+              key={user._id}
+              user={user}
+              right={
+                <div className="flex">
+                  <button
+                    type="button"
+                    className="p-2 rounded-full border border-line active:bg-indigo active:fill-offWhite disabled:bg-offWhite disabled:fill-error-light disabled:cursor-not-allowed"
+                    onClick={() => {}}
+                    disabled={disabled}
+                  >
+                    <span className="sr-only">초대하기</span>
+                    <UserPlusIcon className="w-6 h-6 fill-[inherit] pointer-events-none" />
+                  </button>
+                </div>
+              }
+            />
+          );
+        })}
+      </ul>
+    </Scrollbars>
+  );
+};
+
+export default CommunityInviteUserSearchResultBox;

--- a/client/src/components/ErrorMessage/index.tsx
+++ b/client/src/components/ErrorMessage/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, FC } from 'react';
 
 import React, { memo, useMemo } from 'react';
 
@@ -13,7 +13,7 @@ export interface Props {
   size?: keyof typeof messageSize;
 }
 
-const ErrorMessage: React.FC<Props> = ({ children, size = 'sm' }) => {
+const ErrorMessage: FC<Props> = ({ children, size = 'sm' }) => {
   const memoizedSize = useMemo(() => messageSize[size], [size]);
 
   return <div className={`text-error ${memoizedSize}`}>{children}</div>;

--- a/client/src/components/FollowerUserItem/index.tsx
+++ b/client/src/components/FollowerUserItem/index.tsx
@@ -1,4 +1,5 @@
 import type { User } from '@apis/user';
+import type { FC } from 'react';
 
 import UserItem from '@components/UserItem';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
@@ -8,7 +9,7 @@ interface Props {
   user: User;
 }
 
-const FollowerUserItem: React.FC<Props> = ({ user }) => {
+const FollowerUserItem: FC<Props> = ({ user }) => {
   return (
     <UserItem
       user={user}

--- a/client/src/components/FollowingUserItem/index.tsx
+++ b/client/src/components/FollowingUserItem/index.tsx
@@ -1,4 +1,5 @@
 import type { User } from '@apis/user';
+import type { FC } from 'react';
 
 import UserItem from '@components/UserItem';
 import {
@@ -13,7 +14,7 @@ interface Props {
   user: User;
 }
 
-const FollowingUserItem: React.FC<Props> = ({ user }) => {
+const FollowingUserItem: FC<Props> = ({ user }) => {
   const followingMutation = useFollowingMutation(user._id);
   const { mutate: updateFollowing } = followingMutation;
 

--- a/client/src/components/GnbItemContainer/index.tsx
+++ b/client/src/components/GnbItemContainer/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, FC } from 'react';
 
 import cn from 'classnames';
 import React, { useState, memo, useCallback } from 'react';
@@ -11,7 +11,7 @@ interface Props {
 }
 
 // TODO: Tooltip 추가하기
-const GnbItemContainer: React.FC<Props> = ({
+const GnbItemContainer: FC<Props> = ({
   children,
   disableLeftFillBar = false,
   isActive = false,

--- a/client/src/components/Input/index.tsx
+++ b/client/src/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithRef } from 'react';
+import type { ComponentPropsWithRef, FC } from 'react';
 
 import React, { forwardRef } from 'react';
 
@@ -6,19 +6,17 @@ interface Props extends ComponentPropsWithRef<'input'> {
   className?: string;
 }
 
-const Input: React.FC<Props> = forwardRef(
-  ({ className, ...restProps }, ref) => {
-    return (
-      <div className={`min-w-[280px] h-[40px] rounded-xl ${className}`}>
-        <input
-          {...restProps}
-          ref={ref}
-          className={`border w-full h-full text-s14 rounded-xl px-[12px] border-line bg-inputBackground focus:bg-offWhite disabled:bg-line disabled:opacity-30 disabled:border-line`}
-        />
-      </div>
-    );
-  },
-);
+const Input: FC<Props> = forwardRef(({ className, ...restProps }, ref) => {
+  return (
+    <div className={`min-w-[280px] h-[40px] rounded-xl ${className}`}>
+      <input
+        {...restProps}
+        ref={ref}
+        className={`border w-full h-full text-s14 rounded-xl px-[12px] border-line bg-inputBackground focus:bg-offWhite disabled:bg-line disabled:opacity-30 disabled:border-line`}
+      />
+    </div>
+  );
+});
 
 Input.displayName = 'Input';
 

--- a/client/src/components/Logo/index.tsx
+++ b/client/src/components/Logo/index.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import logoUrl from '@icons/logo.svg';
 import React, { memo } from 'react';
 
@@ -13,7 +15,7 @@ export interface Props {
   size?: keyof typeof logoSize;
 }
 
-const Logo: React.FC<Props> = ({ size = 'md' }) => {
+const Logo: FC<Props> = ({ size = 'md' }) => {
   return (
     <div className="inline-flex">
       <img src={logoUrl} alt="" className={`${logoSize[size]}`} />

--- a/client/src/components/Modals/CommonModal/index.tsx
+++ b/client/src/components/Modals/CommonModal/index.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties } from 'react';
+
+import { useRootStore } from '@stores/rootStore';
+import React, { useMemo } from 'react';
+import ReactModal from 'react-modal';
+
+const OverlayBackground = {
+  black: 'rgba(0, 0, 0, 0.5)',
+  white: 'rgba(255, 255, 255, 0.5)',
+  transparent: 'transparent',
+} as const;
+
+const CommonModal: React.FC = () => {
+  const {
+    isOpen,
+    content: Content,
+    overlayBackground,
+    onCancel,
+    transform,
+    x = 1,
+    y = 1,
+  } = useRootStore((state) => state.commonModal);
+  const closeCommonModal = useRootStore((state) => state.closeCommonModal);
+
+  const overlayStyle: CSSProperties = useMemo(
+    () => ({
+      background: OverlayBackground[overlayBackground],
+    }),
+    [overlayBackground],
+  );
+
+  const contentStyle: CSSProperties = useMemo(
+    () => ({
+      width: 'max-content',
+      height: 'max-content',
+      padding: 0,
+      border: 0,
+      top: y,
+      left: x,
+      transform,
+    }),
+    [x, y, transform],
+  );
+
+  return (
+    <ReactModal
+      isOpen={isOpen}
+      style={{
+        overlay: overlayStyle,
+        content: contentStyle,
+      }}
+      onRequestClose={onCancel ?? closeCommonModal}
+    >
+      {Content}
+    </ReactModal>
+  );
+};
+
+export default CommonModal;

--- a/client/src/components/Modals/CommonModal/index.tsx
+++ b/client/src/components/Modals/CommonModal/index.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, FC } from 'react';
 
 import { useRootStore } from '@stores/rootStore';
 import React, { useMemo } from 'react';
@@ -10,7 +10,7 @@ const OverlayBackground = {
   transparent: 'transparent',
 } as const;
 
-const CommonModal: React.FC = () => {
+const CommonModal: FC = () => {
   const {
     isOpen,
     content: Content,

--- a/client/src/components/Modals/ContextMenuModal/index.tsx
+++ b/client/src/components/Modals/ContextMenuModal/index.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, FC } from 'react';
 
 import CommunityContextMenu from '@components/CommunityContextMenu';
 import { useRootStore } from '@stores/rootStore';
@@ -13,7 +13,7 @@ interface Props {}
 
 ReactModal.setAppElement('#root');
 
-const ContextMenuModal: React.FC<Props> = () => {
+const ContextMenuModal: FC<Props> = () => {
   const { x, y, isOpen, data, type } = useRootStore(
     (state) => state.contextMenuModal,
   );

--- a/client/src/components/Modals/CreateCommunityModal/index.tsx
+++ b/client/src/components/Modals/CreateCommunityModal/index.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import type { CSSProperties, FC } from 'react';
 
 import Button from '@components/Button';
 import ErrorMessage from '@components/ErrorMessage';
@@ -44,7 +44,7 @@ interface Props {}
 
 ReactModal.setAppElement('#root');
 
-const CreateCommunityModal: React.FC<Props> = () => {
+const CreateCommunityModal: FC<Props> = () => {
   const { isOpen } = useRootStore((state) => state.createCommunityModal);
   const closeCreateCommunityModal = useRootStore(
     (state) => state.closeCreateCommunityModal,

--- a/client/src/components/NormalUserSearchResultBox/index.tsx
+++ b/client/src/components/NormalUserSearchResultBox/index.tsx
@@ -1,11 +1,12 @@
 import type { User } from '@apis/user';
+import type { FC } from 'react';
 
 import FollowerUserItem from '@components/FollowerUserItem';
 import UserList from '@components/UserList';
 import React from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
 
-const NormalUserSearchResultBox: React.FC<{ users?: User[] }> = ({ users }) => {
+const NormalUserSearchResultBox: FC<{ users?: User[] }> = ({ users }) => {
   return users ? (
     <Scrollbars>
       {users.length ? (

--- a/client/src/components/NormalUserSearchResultBox/index.tsx
+++ b/client/src/components/NormalUserSearchResultBox/index.tsx
@@ -1,0 +1,28 @@
+import type { User } from '@apis/user';
+
+import FollowerUserItem from '@components/FollowerUserItem';
+import UserList from '@components/UserList';
+import React from 'react';
+import Scrollbars from 'react-custom-scrollbars-2';
+
+const NormalUserSearchResultBox: React.FC<{ users?: User[] }> = ({ users }) => {
+  return users ? (
+    <Scrollbars>
+      {users.length ? (
+        <UserList>
+          {users.map((user) => (
+            <FollowerUserItem key={user._id} user={user} />
+          ))}
+        </UserList>
+      ) : (
+        <div className="flex justify-center items-center">
+          검색된 사용자가 없습니다
+        </div>
+      )}
+    </Scrollbars>
+  ) : (
+    <div />
+  );
+};
+
+export default NormalUserSearchResultBox;

--- a/client/src/components/SearchInput/index.tsx
+++ b/client/src/components/SearchInput/index.tsx
@@ -1,34 +1,33 @@
-import type { InputHTMLAttributes } from 'react';
+import type { ComponentPropsWithRef } from 'react';
 
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
-type SearchInputProps = InputHTMLAttributes<HTMLInputElement>;
+export interface Props extends ComponentPropsWithRef<'input'> {}
 
-const SearchInput: React.FC<SearchInputProps> = ({
-  className,
-  value,
-  onChange,
-  placeholder,
-  ...props
-}) => {
-  return (
-    <div className={`relative h-[40px] ${className}`}>
-      <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-        <span className="sr-only">검색</span>
-        <MagnifyingGlassIcon className="w-5 h-5 fill-label" />
+const SearchInput: React.FC<Props> = forwardRef(
+  ({ className, value, onChange, placeholder, ...restProps }, ref) => {
+    return (
+      <div className={`relative h-[40px] ${className}`}>
+        <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+          <span className="sr-only">검색</span>
+          <MagnifyingGlassIcon className="w-5 h-5 fill-label" />
+        </div>
+        <input
+          {...restProps}
+          ref={ref}
+          type="text"
+          id="input-group-1"
+          className="h-full bg-inputBackground border border-line text-s14 text-label rounded-2xl min-w-full pl-10 focus:outline-line focus:bg-offWhite focus:font-bold"
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+        />
       </div>
-      <input
-        {...props}
-        type="text"
-        id="input-group-1"
-        className="h-full bg-inputBackground border border-line text-s14 text-label rounded-2xl min-w-full pl-10 focus:outline-line focus:bg-offWhite focus:font-bold"
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-      />
-    </div>
-  );
-};
+    );
+  },
+);
+
+SearchInput.displayName = 'SearchInput';
 
 export default SearchInput;

--- a/client/src/components/SearchInput/index.tsx
+++ b/client/src/components/SearchInput/index.tsx
@@ -1,11 +1,11 @@
-import type { ComponentPropsWithRef } from 'react';
+import type { ComponentPropsWithRef, FC } from 'react';
 
 import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
 import React, { forwardRef } from 'react';
 
 export interface Props extends ComponentPropsWithRef<'input'> {}
 
-const SearchInput: React.FC<Props> = forwardRef(
+const SearchInput: FC<Props> = forwardRef(
   ({ className, value, onChange, placeholder, ...restProps }, ref) => {
     return (
       <div className={`relative h-[40px] ${className}`}>

--- a/client/src/components/SuccessMessage/index.tsx
+++ b/client/src/components/SuccessMessage/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, FC } from 'react';
 
 import React, { memo, useMemo } from 'react';
 
@@ -13,7 +13,7 @@ export interface Props {
   size?: keyof typeof messageSize;
 }
 
-const SuccessMessage: React.FC<Props> = ({ children, size = 'sm' }) => {
+const SuccessMessage: FC<Props> = ({ children, size = 'sm' }) => {
   const memoizedSize = useMemo(() => messageSize[size], [size]);
 
   return <div className={`text-success ${memoizedSize}`}>{children}</div>;

--- a/client/src/components/TextButton/index.tsx
+++ b/client/src/components/TextButton/index.tsx
@@ -1,4 +1,9 @@
-import type { ReactNode, ComponentPropsWithoutRef, CSSProperties } from 'react';
+import type {
+  ReactNode,
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  FC,
+} from 'react';
 
 import cn from 'classnames';
 import React from 'react';
@@ -29,7 +34,7 @@ export interface Props extends ComponentPropsWithoutRef<'button'> {
   className?: string;
 }
 
-const TextButton: React.FC<Props> = ({
+const TextButton: FC<Props> = ({
   children,
   size,
   color = 'default',

--- a/client/src/components/UserItem/index.tsx
+++ b/client/src/components/UserItem/index.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@apis/user';
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode, FC } from 'react';
 
 import UserProfile from '@components/UserProfile';
 import React, { memo } from 'react';
@@ -9,7 +9,7 @@ interface Props extends ComponentPropsWithoutRef<'li'> {
   right?: ReactNode;
 }
 
-const UserItem: React.FC<Props> = ({ user, right }) => {
+const UserItem: FC<Props> = ({ user, right }) => {
   return (
     <li className="flex justify-between items-center px-10 min-w-full py-2">
       <UserProfile user={user} />

--- a/client/src/components/UserProfile/index.tsx
+++ b/client/src/components/UserProfile/index.tsx
@@ -20,7 +20,7 @@ const UserProfile: React.FC<Props> = ({
   user: { nickname, profileUrl, status },
 }) => {
   return (
-    <div className="flex items-center gap-[11px] py-2">
+    <div className="flex items-center gap-[11px] py-2 max-w-[220px]">
       <Badge color={STATUS_COLOR[status]}>
         <Avatar
           size="small"
@@ -29,7 +29,9 @@ const UserProfile: React.FC<Props> = ({
           url={profileUrl}
         />
       </Badge>
-      <div className="font-bold text-s16">{nickname}</div>
+      <div className="font-bold text-s14 whitespace-nowrap text-ellipsis overflow-hidden">
+        {nickname}
+      </div>
     </div>
   );
 };

--- a/client/src/components/UserProfile/index.tsx
+++ b/client/src/components/UserProfile/index.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@apis/user';
-import type { ComponentPropsWithoutRef } from 'react';
+import type { ComponentPropsWithoutRef, FC } from 'react';
 
 import Avatar from '@components/Avatar';
 import Badge from '@components/Badge';
@@ -16,9 +16,7 @@ const STATUS_COLOR = {
   [USER_STATUS.AFK]: 'error',
 } as const;
 
-const UserProfile: React.FC<Props> = ({
-  user: { nickname, profileUrl, status },
-}) => {
+const UserProfile: FC<Props> = ({ user: { nickname, profileUrl, status } }) => {
   return (
     <div className="flex items-center gap-[11px] py-2 max-w-[220px]">
       <Badge color={STATUS_COLOR[status]}>

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -6,11 +6,13 @@ import type {
   GetCommunityResult,
   RemoveCommunityResult,
   LeaveCommunityResult,
+  InviteCommunityResult,
 } from '@apis/community';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
 import {
+  inviteCommunity,
   createCommunity,
   getCommunities,
   leaveCommunity,
@@ -130,6 +132,15 @@ export const useLeaveCommunityMutation = (
 ) => {
   const key = queryKeyCreator.community.leaveCommunity();
   const mutation = useMutation(key, leaveCommunity, { ...options });
+
+  return mutation;
+};
+
+export const useInviteCommunityMutation = (
+  options?: UseMutationOptions<InviteCommunityResult, unknown, unknown>,
+) => {
+  const key = queryKeyCreator.community.inviteCommunity();
+  const mutation = useMutation(key, inviteCommunity, { ...options });
 
   return mutation;
 };

--- a/client/src/hooks/useUsersQuery.ts
+++ b/client/src/hooks/useUsersQuery.ts
@@ -1,29 +1,22 @@
-import type { GetUsersResponse, GetUsersResult } from '@apis/user';
+import type { GetUsersResponse, User } from '@apis/user';
 
 import { GetUsers } from '@apis/user';
 import { useQuery } from '@tanstack/react-query';
 
 import queryKeyCreator from '@/queryKeyCreator';
 
-type UsersQueryData = {
-  statusCode: number;
-} & GetUsersResult;
-
 const useUserSearchQuery = (
   filter: string,
   options?: { suspense?: boolean; enabled?: boolean },
 ) => {
   const key = queryKeyCreator.userSearch(filter);
-  const query = useQuery<GetUsersResponse, unknown, UsersQueryData>(
+  const query = useQuery<GetUsersResponse, unknown, User[]>(
     key,
     () => GetUsers({ search: filter }),
     {
       ...options,
       select: (data) => {
-        const { statusCode, result } = data;
-        const { users } = result;
-
-        return { statusCode, ...result, users };
+        return data.result.users;
       },
     },
   );

--- a/client/src/hooks/useUsersQuery.ts
+++ b/client/src/hooks/useUsersQuery.ts
@@ -18,6 +18,7 @@ const useUserSearchQuery = (
       select: (data) => {
         return data.result.users;
       },
+      refetchOnWindowFocus: false,
     },
   );
 

--- a/client/src/hooks/user.ts
+++ b/client/src/hooks/user.ts
@@ -1,4 +1,7 @@
-import { getUser } from '@apis/user';
+import type { User } from '@apis/user';
+import type { AxiosError } from 'axios';
+
+import { getCommunityUsers, getUser } from '@apis/user';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -20,4 +23,24 @@ export const useUserQuery = (
   );
 
   return { userQuery: query, invalidateUserQuery: invalidate };
+};
+
+export const useCommunityUsersQuery = (communityId: string) => {
+  const key = queryKeyCreator.user.communityUsers(communityId);
+
+  const query = useQuery<User[], AxiosError>(key, () =>
+    getCommunityUsers(communityId),
+  );
+
+  return { communityUsersQuery: query };
+};
+
+export const useInvalidateCommunityUsersQuery = (communityId: string) => {
+  const queryClient = useQueryClient();
+  const key = queryKeyCreator.user.communityUsers(communityId);
+
+  const invalidateCommunityUsersQuery = () =>
+    queryClient.invalidateQueries(key);
+
+  return { invalidateCommunityUsersQuery };
 };

--- a/client/src/layouts/UserSearch/index.tsx
+++ b/client/src/layouts/UserSearch/index.tsx
@@ -13,7 +13,7 @@ interface UserSearchInput {
 }
 
 interface Props {
-  Variant: FC<{ users?: User[] }>;
+  Variant: FC<{ users?: User[]; isLoading: boolean; error: unknown }>;
 }
 
 const UserSearch: React.FC<Props> = ({ Variant }) => {
@@ -29,7 +29,7 @@ const UserSearch: React.FC<Props> = ({ Variant }) => {
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full pb-[20px]">
       <div className="w-full p-8">
         <form
           onSubmit={handleSubmit(handleSubmitUserSearchForm)}
@@ -37,7 +37,7 @@ const UserSearch: React.FC<Props> = ({ Variant }) => {
         >
           <SearchInput
             {...register('filter')}
-            placeholder="검색하기"
+            placeholder="닉네임이나 이메일로 검색하기"
             className="flex-1"
           />
           <Button color="dark" size="sm">
@@ -45,7 +45,11 @@ const UserSearch: React.FC<Props> = ({ Variant }) => {
           </Button>
         </form>
       </div>
-      <Variant users={usersQuery?.data} />
+      <Variant
+        users={usersQuery?.data}
+        isLoading={usersQuery.isFetching}
+        error={usersQuery.error}
+      />
     </div>
   );
 };

--- a/client/src/layouts/UserSearch/index.tsx
+++ b/client/src/layouts/UserSearch/index.tsx
@@ -16,7 +16,7 @@ interface Props {
   Variant: FC<{ users?: User[]; isLoading: boolean; error: unknown }>;
 }
 
-const UserSearch: React.FC<Props> = ({ Variant }) => {
+const UserSearch: FC<Props> = ({ Variant }) => {
   const { register, handleSubmit } = useForm<UserSearchInput>();
 
   const [submittedFilter, setSubmittedFilter] = useState('');

--- a/client/src/layouts/UserSearch/index.tsx
+++ b/client/src/layouts/UserSearch/index.tsx
@@ -25,7 +25,9 @@ const UserSearch: React.FC<Props> = ({ Variant }) => {
   });
 
   const handleSubmitUserSearchForm = (data: UserSearchInput) => {
-    setSubmittedFilter(data.filter);
+    if (data.filter.trim()) {
+      setSubmittedFilter(data.filter);
+    }
   };
 
   return (

--- a/client/src/layouts/UserSearch/index.tsx
+++ b/client/src/layouts/UserSearch/index.tsx
@@ -1,37 +1,42 @@
-import type { FormEvent } from 'react';
+import type { User } from '@apis/user';
+import type { FC } from 'react';
 
-import FollowerUserItem from '@components/FollowerUserItem';
 import SearchInput from '@components/SearchInput';
-import UserList from '@components/UserList';
 import useUsersQuery from '@hooks/useUsersQuery';
 import React, { useState } from 'react';
-import Scrollbars from 'react-custom-scrollbars-2';
+import { useForm } from 'react-hook-form';
 
 import Button from '@/components/Button';
 
-// TODO: `handleKeyDown` 이벤트 핸들러 네이밍 명확하게 지어야함
-const UserSearch = () => {
+interface UserSearchInput {
+  filter: string;
+}
+
+interface Props {
+  Variant: FC<{ users?: User[] }>;
+}
+
+const UserSearch: React.FC<Props> = ({ Variant }) => {
+  const { register, handleSubmit } = useForm<UserSearchInput>();
+
   const [submittedFilter, setSubmittedFilter] = useState('');
   const usersQuery = useUsersQuery(submittedFilter, {
     enabled: !!submittedFilter,
   });
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const filter =
-      (new FormData(e.currentTarget).get('user-search') as string) ?? '';
-
-    if (filter.length === 0) return;
-
-    setSubmittedFilter(filter);
+  const handleSubmitUserSearchForm = (data: UserSearchInput) => {
+    setSubmittedFilter(data.filter);
   };
 
   return (
     <div className="flex flex-col h-full">
       <div className="w-full p-8">
-        <form onSubmit={handleSubmit} className="flex gap-2 items-center">
+        <form
+          onSubmit={handleSubmit(handleSubmitUserSearchForm)}
+          className="flex gap-2 items-center"
+        >
           <SearchInput
-            name="user-search"
+            {...register('filter')}
             placeholder="검색하기"
             className="flex-1"
           />
@@ -40,19 +45,7 @@ const UserSearch = () => {
           </Button>
         </form>
       </div>
-      <Scrollbars>
-        {usersQuery.data?.users.length ? (
-          <UserList>
-            {usersQuery.data.users.map((user) => (
-              <FollowerUserItem key={user._id} user={user} />
-            ))}
-          </UserList>
-        ) : (
-          <div className="flex justify-center items-center">
-            검색된 사용자가 없습니다
-          </div>
-        )}
-      </Scrollbars>
+      <Variant users={usersQuery?.data} />
     </div>
   );
 };

--- a/client/src/mocks/data/users.js
+++ b/client/src/mocks/data/users.js
@@ -12,3 +12,4 @@ export const createMockUser = () => ({
 });
 
 export const users = [...Array(30)].map(createMockUser);
+export const communityUsers = users.slice(0, 10);

--- a/client/src/mocks/handlers/Community.js
+++ b/client/src/mocks/handlers/Community.js
@@ -2,6 +2,7 @@ import { API_URL } from '@constants/url';
 import { rest } from 'msw';
 
 import { communities } from '../data/communities';
+import { communityUsers, users } from '../data/users';
 import {
   createErrorContext,
   createSuccessContext,
@@ -88,7 +89,7 @@ const CreateCommunity = rest.post(
   },
 );
 
-export const LeaveCommunity = rest.delete(
+const LeaveCommunity = rest.delete(
   `${BASE_URL}/community/:id/me`,
   (req, res, ctx) => {
     const { id } = req.params;
@@ -117,4 +118,36 @@ export const LeaveCommunity = rest.delete(
   },
 );
 
-export default [GetCommunities, GetCommunity, CreateCommunity, LeaveCommunity];
+const InviteCommunity = rest.post(
+  `${BASE_URL}/community/:id/participants`,
+  async (req, res, ctx) => {
+    const { users: userIds } = await req.json();
+
+    const ERROR = false;
+    const successDelay = 500;
+
+    const successResponse = res(
+      ...createSuccessContext(ctx, 201, successDelay, {
+        message: '커뮤니티 초대 성공~',
+      }),
+    );
+
+    const errorResponse = res(...createErrorContext(ctx));
+
+    if (!ERROR) {
+      setTimeout(() => {
+        communityUsers.push(users.find(({ _id }) => _id === userIds[0]));
+      }, successDelay);
+    }
+
+    return ERROR ? errorResponse : successResponse;
+  },
+);
+
+export default [
+  GetCommunities,
+  GetCommunity,
+  CreateCommunity,
+  LeaveCommunity,
+  InviteCommunity,
+];

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -1,7 +1,7 @@
 import { API_URL } from '@constants/url';
 import { rest } from 'msw';
 
-import { users } from '../data/users';
+import { communityUsers, users } from '../data/users';
 import {
   createErrorContext,
   createSuccessContext,
@@ -42,11 +42,8 @@ const GetCommunityUsers = rest.get(
   (req, res, ctx) => {
     const ERROR = false;
 
-    const communityUsers = [...users];
-
-    // users는 사용자 배열이고, communityUsers는 그중 일부만 가져와서
+    // communityUsers는 users의 부분집합
     // 커뮤니티 초대 모달에서 유저를 검색하면, 일부는 이미 커뮤니티에 속해있는 것을 재현할 수 있음.
-    communityUsers.splice(0, 10);
 
     const errorResponse = res(...createErrorContext(ctx));
     const successResponse = res(

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -7,7 +7,9 @@ import {
   createSuccessContext,
 } from '../utils/createContext';
 
-const GetFilteredUsers = rest.get(`${API_URL}/api/users`, (req, res, ctx) => {
+const BASE_URL = `${API_URL}/api`;
+
+const GetFilteredUsers = rest.get(`${BASE_URL}/users`, (req, res, ctx) => {
   const search = req.url.searchParams.get('search').toUpperCase();
 
   return res(
@@ -26,7 +28,7 @@ const GetFilteredUsers = rest.get(`${API_URL}/api/users`, (req, res, ctx) => {
   );
 });
 
-const GetUser = rest.get(`${API_URL}/api/users/:userId`, (req, res, ctx) => {
+const GetUser = rest.get(`${BASE_URL}/users/:userId`, (req, res, ctx) => {
   const ERROR = false;
 
   const errorResponse = res(...createErrorContext(ctx));
@@ -35,4 +37,24 @@ const GetUser = rest.get(`${API_URL}/api/users/:userId`, (req, res, ctx) => {
   return ERROR ? errorResponse : successResponse;
 });
 
-export default [GetFilteredUsers, GetUser];
+const GetCommunityUsers = rest.get(
+  `${BASE_URL}/community/:communityId/participants`,
+  (req, res, ctx) => {
+    const ERROR = false;
+
+    const communityUsers = [...users];
+
+    // users는 사용자 배열이고, communityUsers는 그중 일부만 가져와서
+    // 커뮤니티 초대 모달에서 유저를 검색하면, 일부는 이미 커뮤니티에 속해있는 것을 재현할 수 있음.
+    communityUsers.splice(0, 10);
+
+    const errorResponse = res(...createErrorContext(ctx));
+    const successResponse = res(
+      ...createSuccessContext(ctx, 200, 500, { users: communityUsers }),
+    );
+
+    return ERROR ? errorResponse : successResponse;
+  },
+);
+
+export default [GetFilteredUsers, GetUser, GetCommunityUsers];

--- a/client/src/pages/Friends/index.tsx
+++ b/client/src/pages/Friends/index.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 
+import NormalUserSearchResultBox from '@components/NormalUserSearchResultBox';
 import Followers from '@layouts/Followers';
 import Followings from '@layouts/Followings';
 import UserSearch from '@layouts/UserSearch';
@@ -32,7 +33,7 @@ const tabs = [
 const TabPanel: Record<string, ReactNode> = {
   [TAB.FOLLOWINGS]: <Followings />,
   [TAB.FOLLOWERS]: <Followers />,
-  [TAB.USER_SEARCH]: <UserSearch />,
+  [TAB.USER_SEARCH]: <UserSearch Variant={NormalUserSearchResultBox} />,
 };
 
 const DEFAULT_TAB = TAB.FOLLOWINGS;

--- a/client/src/pages/Friends/index.tsx
+++ b/client/src/pages/Friends/index.tsx
@@ -50,8 +50,10 @@ const Friends = () => {
           {tabs.map(({ name, tab: t }) => (
             <li
               key={t}
-              className={`${tab === t ? 'text-indigo' : 'text-placeholder'
-                } font-bold text-s20`}
+              className={`${
+                // 강제 포맷 방지용 주석
+                tab === t ? 'text-indigo' : 'text-placeholder'
+              } font-bold text-s20`}
             >
               <button className="w-[100%]" onClick={() => setTab(t)}>
                 {name}

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -1,4 +1,5 @@
 import AlertModal from '@components/Modals/AlertModal';
+import CommonModal from '@components/Modals/CommonModal';
 import ContextMenuModal from '@components/Modals/ContextMenuModal';
 import CreateCommunityModal from '@components/Modals/CreateCommunityModal';
 import Gnb from '@layouts/Gnb';
@@ -15,6 +16,7 @@ const Home = () => {
       <CreateCommunityModal />
       <ContextMenuModal />
       <AlertModal />
+      <CommonModal />
     </div>
   );
 };

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -19,6 +19,7 @@ const communityQueryKey = {
   detail: (communityId: string) =>
     [...communityQueryKey.all(), 'detail', communityId] as const,
   leaveCommunity: () => ['leaveCommunity'] as const,
+  inviteCommunity: () => ['inviteCommunity'] as const,
 };
 
 const channelQueryKey = {

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -2,6 +2,8 @@ const userQueryKey = {
   all: () => ['users'] as const,
   detail: (userId: string) =>
     [...userQueryKey.all(), 'detail', userId] as const,
+  communityUsers: (communityId: string) =>
+    [...userQueryKey.all(), { communityId }] as const,
 };
 
 const directMessageQueryKey = {

--- a/client/src/stores/commonModalSlice.ts
+++ b/client/src/stores/commonModalSlice.ts
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+import type { StateCreator } from 'zustand';
+
+import { immer } from 'zustand/middleware/immer';
+
+type OverlayBackground = 'white' | 'black' | 'transparent';
+
+export interface CommonModal {
+  isOpen: boolean;
+  content: ReactNode;
+  overlayBackground: OverlayBackground;
+  onCancel: () => void;
+  onSubmit: () => void;
+}
+
+type SetCommonModal = (commonModalState: Partial<CommonModal>) => void;
+type OpenCommonModal = (
+  commonModalState: Partial<Omit<CommonModal, 'isOpen'>>,
+) => void;
+
+export interface CommonModalSlice {
+  commonModal: CommonModal;
+  setCommonModal: SetCommonModal;
+  openCommonModal: OpenCommonModal;
+  closeCommonModal: () => void;
+}
+
+const defaultHandler = () => {};
+
+const initialCommonModalValue = {
+  isOpen: false,
+  content: null,
+  overlayBackground: 'transparent',
+  onCancel: defaultHandler,
+  onSubmit: defaultHandler,
+} as const;
+
+export const commonModalSlice: StateCreator<
+  CommonModalSlice,
+  [],
+  [['zustand/immer', never], ...[]],
+  CommonModalSlice
+> = immer((set) => ({
+  commonModal: initialCommonModalValue,
+  setCommonModal: (commonModalState) =>
+    set((state) => {
+      state.commonModal = {
+        ...state.commonModal,
+        ...commonModalState,
+      };
+    }),
+  openCommonModal: (commonModalState) =>
+    set((state) => {
+      state.commonModal = {
+        ...state.commonModal,
+        ...commonModalState,
+        isOpen: true,
+      };
+    }),
+  closeCommonModal: () =>
+    set((state) => {
+      state.commonModal = initialCommonModalValue;
+    }),
+}));

--- a/client/src/stores/commonModalSlice.ts
+++ b/client/src/stores/commonModalSlice.ts
@@ -7,10 +7,13 @@ type OverlayBackground = 'white' | 'black' | 'transparent';
 
 export interface CommonModal {
   isOpen: boolean;
-  content: ReactNode;
   overlayBackground: OverlayBackground;
-  onCancel: () => void;
-  onSubmit: () => void;
+  x: number | string;
+  y: number | string;
+  transform?: string;
+  content?: ReactNode;
+  onCancel?: () => void;
+  onSubmit?: () => void;
 }
 
 type SetCommonModal = (commonModalState: Partial<CommonModal>) => void;
@@ -25,14 +28,15 @@ export interface CommonModalSlice {
   closeCommonModal: () => void;
 }
 
-const defaultHandler = () => {};
-
 const initialCommonModalValue = {
   isOpen: false,
-  content: null,
+  content: undefined,
   overlayBackground: 'transparent',
-  onCancel: defaultHandler,
-  onSubmit: defaultHandler,
+  onCancel: undefined,
+  onSubmit: undefined,
+  transform: undefined,
+  x: 0,
+  y: 0,
 } as const;
 
 export const commonModalSlice: StateCreator<

--- a/client/src/stores/commonModalSlice.ts
+++ b/client/src/stores/commonModalSlice.ts
@@ -7,6 +7,7 @@ type OverlayBackground = 'white' | 'black' | 'transparent';
 
 export interface CommonModal {
   isOpen: boolean;
+  data?: unknown;
   overlayBackground: OverlayBackground;
   x: number | string;
   y: number | string;
@@ -30,6 +31,7 @@ export interface CommonModalSlice {
 
 const initialCommonModalValue = {
   isOpen: false,
+  data: undefined,
   content: undefined,
   overlayBackground: 'transparent',
   onCancel: undefined,

--- a/client/src/stores/rootStore.ts
+++ b/client/src/stores/rootStore.ts
@@ -1,8 +1,10 @@
 import type { AlertModalSlice } from '@stores/alertModalSlice';
+import type { CommonModalSlice } from '@stores/commonModalSlice';
 import type { ContextMenuModalSlice } from '@stores/contextMenuModalSlice';
 import type { CreateCommunityModalSlice } from '@stores/createCommunityModalSlice';
 
 import { alertModalSlice } from '@stores/alertModalSlice';
+import { commonModalSlice } from '@stores/commonModalSlice';
 import { contextMenuModalSlice } from '@stores/contextMenuModalSlice';
 import { createCommunityModalSlice } from '@stores/createCommunityModalSlice';
 import store from 'zustand';
@@ -10,12 +12,14 @@ import { devtools } from 'zustand/middleware';
 
 export type Store = CreateCommunityModalSlice &
   ContextMenuModalSlice &
-  AlertModalSlice;
+  AlertModalSlice &
+  CommonModalSlice;
 
 export const useRootStore = store<Store>()(
   devtools((...a) => ({
     ...createCommunityModalSlice(...a),
     ...contextMenuModalSlice(...a),
     ...alertModalSlice(...a),
+    ...commonModalSlice(...a),
   })),
 );


### PR DESCRIPTION
## Issues
- #173
- #184 

<!-- 어떤 이슈와 관련된 PR인지 적어주세요! 이슈와 PR을 연결하려면 반드시 적어야 합니다. -->
<!-- 필요하다면 여러 이슈를 적는 것도 가능할지도? -->
<!-- - #IssueNumber 로 타이핑하면 자동완성되는 문장을 사용해주세요. -->
<!-- 예시) - #1 -->

## 🤷‍♂️ Description

<!-- 어떤 문제에 관한 PR인지 간략하게 적어주세요. -->


## 📝 Primary Commits
 
- [X] Common 모달 추가. 
  - Common 모달 전역상태는 다음과 같습니다.
  ```tsx
  isOpen: boolean;
  data?: unknown;
  overlayBackground: OverlayBackground;
  x: number | string;
  y: number | string;
  transform?: string;
  content?: ReactNode;
  onCancel?: () => void;
  onSubmit?: () => void;
  ```
  - 모달에 전달하는 데이터는 제네릭으로 사용할 수 있도록 타이핑해보려 했는데, 포기했습니다.. 그래서 일단은 `assertion`쓰는 방식으로 사용해야 합니다.
  - onSubmit, onCancel은 Alert Modal 아니면 거의 사용 안할듯 합니다.
  - content가 모달 내부에서 표시될 박스입니다. 
  - 오버레이 배경색은 흰색, 검은색, 투명색 세가지입니다.

- [X] UserSearch를 조금 더 추상화 -> 사용자 검색으로 재사용, 검색 결과 부분만 Props로 받아서 다양하게 렌더링할 수 있도록
- [X] 사용자 검색창 리팩토링 (`react-hook-form`사용했습니다.)
- [X] 커뮤니티에 속해있는 유저목록 가져오는 mock api, 커스텀 훅 추가
- [X] 강제 포맷 방지용 주석
- [X] React.FC -> FC

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
 
![초대](https://user-images.githubusercontent.com/79135734/204379686-c7666c81-cf31-4bbd-9916-c9e6039ffae6.gif)

## 📒 Remarks

저녁에 말씀하신 api 일관성 문제때문에 백엔드에서 명세 바뀌면 따로 업데이트 할 예정입니다. 지금은 일단 communityId를 body가 아닌, api endpoint에 포함시키는 형태로 처리했습니다. 

**시간날때 설명을 위한 코멘트 남길 예정이므로, 리뷰 서두르지 않으셔도 됩니다.**


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
