### PR TITLE
[Server] 유저 버그 수정 및 채널 리펙토링

### DIFF
--- a/server/apps/api/src/auth/auth.controller.ts
+++ b/server/apps/api/src/auth/auth.controller.ts
@@ -1,14 +1,28 @@
-import { Body, Controller, Get, Post, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Inject,
+  LoggerService,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SignInDto, SignUpDto } from './dto';
 import { responseForm } from '@utils/responseForm';
 import { Response } from 'express';
 import { getUserBasicInfo } from '@user/dto/user-basic-info.dto';
 import { JwtAccessGuard, JwtRefreshGuard } from '@api/src/auth/guard';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 
 @Controller('api/user/auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService,
+    private authService: AuthService,
+  ) {}
 
   @Post('signup') // 회원가입
   async signUp(@Body() signUpDto: SignUpDto) {
@@ -18,40 +32,59 @@ export class AuthController {
 
   @Post('signin') // 로그인
   async signIn(@Body() signInDto: SignInDto, @Res({ passthrough: true }) res: Response) {
-    const { refreshToken, accessToken } = await this.authService.signIn(signInDto);
+    try {
+      const { refreshToken, accessToken } = await this.authService.signIn(signInDto);
+      // refreshToken 쿠키에 구워줌
+      res.cookie('refreshToken', refreshToken, {
+        path: '/api/user/auth/refresh',
+        httpOnly: true,
+        secure: false,
+        maxAge: 360000000, // 100시간 만료
+      });
 
-    // refreshToken 쿠키에 구워줌
-    res.cookie('refreshToken', refreshToken, {
-      path: '/api/user/auth/refresh',
-      httpOnly: true,
-      secure: false,
-      maxAge: 360000000, // 100시간 만료
-    });
-
-    return responseForm(200, { message: '로그인 성공!', accessToken });
+      return responseForm(200, { message: '로그인 성공!', accessToken });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
   }
 
   @Post('refresh') // AccessToken 재발행
   @UseGuards(JwtRefreshGuard)
   async refresh(@Req() req: any) {
-    const accessToken = req.user;
-    if (accessToken === null) {
-      return responseForm(401, { message: '로그인 필요' });
+    try {
+      const accessToken = req.user;
+      if (accessToken === null) {
+        return responseForm(401, { message: '로그인 필요' });
+      }
+      return responseForm(200, { message: 'accessToken 재발행 성공!', accessToken });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
     }
-    return responseForm(200, { message: 'accessToken 재발행 성공!', accessToken });
   }
 
   @Get('me') // 자신의 유저 정보 제공
   @UseGuards(JwtAccessGuard)
   async getMyInfo(@Req() req: any) {
-    return getUserBasicInfo(req.user);
+    try {
+      return responseForm(200, getUserBasicInfo(req.user));
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
   }
 
   @Post('signout')
   @UseGuards(JwtAccessGuard)
   async singOut(@Req() req: any, @Res({ passthrough: true }) res: Response) {
-    await this.authService.signOut(req.user._id); // DB에서 refreshToken 제거
-    res.cookie('refreshToken', 'expired', { maxAge: -1 }); // client에서 refreshToken 제거
-    return responseForm(200, { message: '로그아웃 성공!' });
+    try {
+      await this.authService.signOut(req.user._id); // DB에서 refreshToken 제거
+      res.cookie('refreshToken', 'expired', { maxAge: -1 }); // client에서 refreshToken 제거
+      return responseForm(200, { message: '로그아웃 성공!' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
   }
 }

--- a/server/apps/api/src/auth/auth.service.ts
+++ b/server/apps/api/src/auth/auth.service.ts
@@ -37,7 +37,7 @@ export class AuthService {
     const refreshToken = await this.signToken.signRefreshToken(user._id);
 
     // DB에 refreshToken 업데이트
-    this.userRepository.updateOne({ _id: user._id }, { refreshToken });
+    this.userRepository.updateOne({ _id: user._id }, { status: 'ONLINE', refreshToken });
 
     return { accessToken, refreshToken };
   }

--- a/server/apps/api/src/auth/auth.service.ts
+++ b/server/apps/api/src/auth/auth.service.ts
@@ -44,7 +44,7 @@ export class AuthService {
 
   async signOut(userId: string) {
     try {
-      await this.userRepository.updateOne({ _id: userId }, { refreshToken: '' });
+      await this.userRepository.updateOne({ _id: userId }, { status: 'OFFLINE', refreshToken: '' });
     } catch (error) {
       throw new ForbiddenException('잘못된 접근입니다.');
     }

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -15,9 +15,9 @@ export class ChannelController {
   @Post()
   @UseGuards(JwtAccessGuard)
   async createChannel(@Body() createChannelDto: CreateChannelDto, @Req() req: any) {
-    const _id = req.user._id;
+    const requestUserId = req.user._id;
     try {
-      await this.channelService.createChannel({ ...createChannelDto, managerId: _id });
+      await this.channelService.createChannel({ ...createChannelDto, managerId: requestUserId });
       return responseForm(200, { message: '채널 생성 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -1,26 +1,9 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Inject,
-  LoggerService,
-  Param,
-  Patch,
-  Post,
-  Req,
-  UseGuards,
-} from '@nestjs/common';
-import { responseForm } from '@utils/responseForm';
+import { Body, Controller, Inject, LoggerService, Post, Req, UseGuards } from '@nestjs/common';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { ChannelService } from '@channel/channel.service';
-import {
-  CreateChannelDto,
-  InviteChannelDto,
-  ModifyChannelDto,
-  UpdateLastReadDto,
-} from '@channel/dto';
 import { JwtAccessGuard } from '@auth/guard';
+import { CreateChannelDto } from '@channel/dto';
+import { responseForm } from '@utils/responseForm';
 
 @Controller('api/channel')
 export class ChannelController {
@@ -36,82 +19,6 @@ export class ChannelController {
     try {
       await this.channelService.createChannel({ ...createChannelDto, managerId: _id });
       return responseForm(200, { message: '채널 생성 성공!' });
-    } catch (error) {
-      this.logger.error(JSON.stringify(error.response));
-      throw error;
-    }
-  }
-
-  @Patch('settings')
-  @UseGuards(JwtAccessGuard)
-  async modifyChannel(@Body() modifyChannelDto: ModifyChannelDto, @Req() req: any) {
-    const _id = req.user._id;
-    try {
-      await this.channelService.modifyChannel({ ...modifyChannelDto, managerId: _id });
-      return responseForm(200, { message: '채널 수정 성공!' });
-    } catch (error) {
-      this.logger.error(JSON.stringify(error.response));
-      throw error;
-    }
-  }
-
-  @Delete('/:channel_id/me')
-  @UseGuards(JwtAccessGuard)
-  async exitChannel(@Param('channel_id') channel_id, @Req() req: any) {
-    const user_id = req.user._id;
-    try {
-      await this.channelService.exitChannel({ channel_id, user_id });
-      return responseForm(200, { message: '채널 퇴장 성공!' });
-    } catch (error) {
-      this.logger.error(JSON.stringify(error.response));
-      throw error;
-    }
-  }
-
-  @Get(':id')
-  @UseGuards(JwtAccessGuard)
-  async getChannelInfo(@Param('id') channel_id: string) {
-    try {
-      const channelInfo = await this.channelService.getChannelInfo(channel_id);
-      return responseForm(200, channelInfo);
-    } catch (error) {
-      this.logger.error(JSON.stringify(error.response));
-      throw error;
-    }
-  }
-
-  @Delete(':channel_id')
-  @UseGuards(JwtAccessGuard)
-  async deleteChannel(@Param('channel_id') channel_id, @Req() req: any) {
-    const user_id = req.user._id;
-    try {
-      await this.channelService.deleteChannel({ channel_id, user_id });
-      return responseForm(200, { message: '채널 삭제 성공' });
-    } catch (error) {
-      this.logger.error(JSON.stringify(error.response));
-      throw error;
-    }
-  }
-
-  @Post('invite')
-  @UseGuards(JwtAccessGuard)
-  async inviteChannel(@Body() inviteChannelDto: InviteChannelDto) {
-    try {
-      await this.channelService.inviteChannel(inviteChannelDto);
-      return responseForm(200, { message: '채널 초대 성공' });
-    } catch (error) {
-      this.logger.error(JSON.stringify(error.response));
-      throw error;
-    }
-  }
-
-  @Post('update/lastRead')
-  @UseGuards(JwtAccessGuard)
-  async updateLastRead(@Body() updateLastReaddto: UpdateLastReadDto, @Req() req: any) {
-    const user_id = req.user._id;
-    try {
-      await this.channelService.updateLastRead({ ...updateLastReaddto, user_id });
-      return responseForm(200, { message: 'Last Read 업데이트 성공' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
       throw error;

--- a/server/apps/api/src/channel/channel.module.ts
+++ b/server/apps/api/src/channel/channel.module.ts
@@ -9,6 +9,7 @@ import { CommunityRepository } from '@repository/community.repository';
 import { CommunityModule } from '@community/community.module';
 import { UserRepository } from '@repository/user.repository';
 import { UserModule } from '@user/user.module';
+import { ChannelsController } from '@channel/channels.controller';
 
 @Module({
   imports: [
@@ -16,7 +17,7 @@ import { UserModule } from '@user/user.module';
     forwardRef(() => CommunityModule),
     UserModule,
   ],
-  controllers: [ChannelController],
+  controllers: [ChannelController, ChannelsController],
   providers: [ChannelService, ChannelRepository, CommunityRepository, UserRepository],
   exports: [MongooseModule],
 })

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -146,9 +146,9 @@ export class ChannelService {
   }
 
   async inviteChannel(inviteChannelDto: InviteChannelDto) {
-    const { community_id, channel_id, inviteUsers } = inviteChannelDto;
+    const { community_id, channel_id, users } = inviteChannelDto;
     // 유저 도큐먼트의 커뮤니티:채널 필드 업데이트
-    await this.addUserToChannel(community_id, channel_id, inviteUsers);
+    await this.addUserToChannel(community_id, channel_id, users);
   }
 
   async updateLastRead(updateLastReadDto: UpdateLastReadDto) {

--- a/server/apps/api/src/channel/channels.controller.ts
+++ b/server/apps/api/src/channel/channels.controller.ts
@@ -1,0 +1,102 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  LoggerService,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { responseForm } from '@utils/responseForm';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { ChannelService } from '@channel/channel.service';
+import { InviteChannelDto, ModifyChannelDto, UpdateLastReadDto } from '@channel/dto';
+import { JwtAccessGuard } from '@auth/guard';
+
+@Controller('api/channels')
+export class ChannelsController {
+  constructor(
+    @Inject(WINSTON_MODULE_NEST_PROVIDER) private readonly logger: LoggerService,
+    private channelService: ChannelService,
+  ) {}
+
+  @Patch('settings')
+  @UseGuards(JwtAccessGuard)
+  async modifyChannel(@Body() modifyChannelDto: ModifyChannelDto, @Req() req: any) {
+    const _id = req.user._id;
+    try {
+      await this.channelService.modifyChannel({ ...modifyChannelDto, managerId: _id });
+      return responseForm(200, { message: '채널 수정 성공!' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+
+  @Delete('/:channel_id/me')
+  @UseGuards(JwtAccessGuard)
+  async exitChannel(@Param('channel_id') channel_id, @Req() req: any) {
+    const user_id = req.user._id;
+    try {
+      await this.channelService.exitChannel({ channel_id, user_id });
+      return responseForm(200, { message: '채널 퇴장 성공!' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAccessGuard)
+  async getChannelInfo(@Param('id') channel_id: string) {
+    try {
+      const channelInfo = await this.channelService.getChannelInfo(channel_id);
+      return responseForm(200, channelInfo);
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+
+  @Delete(':channel_id')
+  @UseGuards(JwtAccessGuard)
+  async deleteChannel(@Param('channel_id') channel_id, @Req() req: any) {
+    const user_id = req.user._id;
+    try {
+      await this.channelService.deleteChannel({ channel_id, user_id });
+      return responseForm(200, { message: '채널 삭제 성공' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+
+  @Post('invite')
+  @UseGuards(JwtAccessGuard)
+  async inviteChannel(@Body() inviteChannelDto: InviteChannelDto) {
+    try {
+      await this.channelService.inviteChannel(inviteChannelDto);
+      return responseForm(200, { message: '채널 초대 성공' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+
+  @Post('update/lastRead')
+  @UseGuards(JwtAccessGuard)
+  async updateLastRead(@Body() updateLastReaddto: UpdateLastReadDto, @Req() req: any) {
+    const user_id = req.user._id;
+    try {
+      await this.channelService.updateLastRead({ ...updateLastReaddto, user_id });
+      return responseForm(200, { message: 'Last Read 업데이트 성공' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
+}

--- a/server/apps/api/src/channel/channels.controller.ts
+++ b/server/apps/api/src/channel/channels.controller.ts
@@ -24,12 +24,16 @@ export class ChannelsController {
     private channelService: ChannelService,
   ) {}
 
-  @Patch('settings')
+  @Patch(':channel_id/settings')
   @UseGuards(JwtAccessGuard)
-  async modifyChannel(@Body() modifyChannelDto: ModifyChannelDto, @Req() req: any) {
-    const _id = req.user._id;
+  async modifyChannel(
+    @Param('channel_id') channel_id,
+    @Body() modifyChannelDto: ModifyChannelDto,
+    @Req() req: any,
+  ) {
+    const requestUserId = req.user._id;
     try {
-      await this.channelService.modifyChannel({ ...modifyChannelDto, managerId: _id });
+      await this.channelService.modifyChannel({ ...modifyChannelDto, channel_id, requestUserId });
       return responseForm(200, { message: '채널 수정 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
@@ -37,12 +41,12 @@ export class ChannelsController {
     }
   }
 
-  @Delete('/:channel_id/me')
+  @Delete(':channel_id/me')
   @UseGuards(JwtAccessGuard)
   async exitChannel(@Param('channel_id') channel_id, @Req() req: any) {
-    const user_id = req.user._id;
+    const requestUserId = req.user._id;
     try {
-      await this.channelService.exitChannel({ channel_id, user_id });
+      await this.channelService.exitChannel({ channel_id, requestUserId });
       return responseForm(200, { message: '채널 퇴장 성공!' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
@@ -50,9 +54,9 @@ export class ChannelsController {
     }
   }
 
-  @Get(':id')
+  @Get(':channel_id')
   @UseGuards(JwtAccessGuard)
-  async getChannelInfo(@Param('id') channel_id: string) {
+  async getChannelInfo(@Param('channel_id') channel_id: string) {
     try {
       const channelInfo = await this.channelService.getChannelInfo(channel_id);
       return responseForm(200, channelInfo);
@@ -65,9 +69,9 @@ export class ChannelsController {
   @Delete(':channel_id')
   @UseGuards(JwtAccessGuard)
   async deleteChannel(@Param('channel_id') channel_id, @Req() req: any) {
-    const user_id = req.user._id;
+    const requestUserId = req.user._id;
     try {
-      await this.channelService.deleteChannel({ channel_id, user_id });
+      await this.channelService.deleteChannel({ channel_id, requestUserId });
       return responseForm(200, { message: '채널 삭제 성공' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
@@ -75,11 +79,11 @@ export class ChannelsController {
     }
   }
 
-  @Post('invite')
+  @Post(':channel_id/users')
   @UseGuards(JwtAccessGuard)
-  async inviteChannel(@Body() inviteChannelDto: InviteChannelDto) {
+  async inviteChannel(@Param('channel_id') channel_id, @Body() inviteChannelDto: InviteChannelDto) {
     try {
-      await this.channelService.inviteChannel(inviteChannelDto);
+      await this.channelService.inviteChannel({ ...inviteChannelDto, channel_id });
       return responseForm(200, { message: '채널 초대 성공' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));
@@ -87,12 +91,16 @@ export class ChannelsController {
     }
   }
 
-  @Post('update/lastRead')
+  @Patch(':channel_id/lastRead')
   @UseGuards(JwtAccessGuard)
-  async updateLastRead(@Body() updateLastReaddto: UpdateLastReadDto, @Req() req: any) {
-    const user_id = req.user._id;
+  async updateLastRead(
+    @Param('channel_id') channel_id,
+    @Body() updateLastReadDto: UpdateLastReadDto,
+    @Req() req: any,
+  ) {
+    const requestUserId = req.user._id;
     try {
-      await this.channelService.updateLastRead({ ...updateLastReaddto, user_id });
+      await this.channelService.updateLastRead({ ...updateLastReadDto, requestUserId, channel_id });
       return responseForm(200, { message: 'Last Read 업데이트 성공' });
     } catch (error) {
       this.logger.error(JSON.stringify(error.response));

--- a/server/apps/api/src/channel/dto/delete-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/delete-channel.dto.ts
@@ -7,5 +7,5 @@ export class DeleteChannelDto {
 
   @IsString()
   @IsNotEmpty()
-  user_id: string;
+  requestUserId: string;
 }

--- a/server/apps/api/src/channel/dto/exit-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/exit-channel.dto.ts
@@ -7,5 +7,5 @@ export class ExitChannelDto {
 
   @IsString()
   @IsNotEmpty()
-  user_id: string;
+  requestUserId: string;
 }

--- a/server/apps/api/src/channel/dto/invite-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/invite-channel.dto.ts
@@ -10,5 +10,5 @@ export class InviteChannelDto {
   channel_id: string;
 
   @IsNotEmpty()
-  inviteUserList: string[];
+  inviteUsers: string[];
 }

--- a/server/apps/api/src/channel/dto/invite-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/invite-channel.dto.ts
@@ -10,5 +10,5 @@ export class InviteChannelDto {
   channel_id: string;
 
   @IsNotEmpty()
-  inviteUsers: string[];
+  users: string[];
 }

--- a/server/apps/api/src/channel/dto/invite-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/invite-channel.dto.ts
@@ -6,9 +6,9 @@ export class InviteChannelDto {
   community_id: string;
 
   @IsString()
-  @IsNotEmpty()
+  @IsOptional()
   channel_id: string;
 
-  @IsOptional()
+  @IsNotEmpty()
   inviteUserList: string[];
 }

--- a/server/apps/api/src/channel/dto/modify-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/modify-channel.dto.ts
@@ -1,10 +1,10 @@
-import { IsBoolean, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export class ModifyChannelDto {
   @IsString()
-  @IsNotEmpty()
-  channelId: string;
+  @IsOptional()
+  channel_id: string;
 
   @IsString()
   @IsOptional()
@@ -12,7 +12,7 @@ export class ModifyChannelDto {
 
   @IsString()
   @IsOptional()
-  managerId: string;
+  requestUserId: string;
 
   @IsString()
   @IsOptional()

--- a/server/apps/api/src/channel/dto/update-last-read.dto.ts
+++ b/server/apps/api/src/channel/dto/update-last-read.dto.ts
@@ -5,13 +5,13 @@ import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 export class UpdateLastReadDto {
   @IsString()
   @IsOptional()
-  user_id: string;
+  requestUserId: string;
 
   @IsString()
   @IsNotEmpty()
   community_id: string;
 
   @IsString()
-  @IsNotEmpty()
+  @IsOptional()
   channel_id: string;
 }

--- a/server/apps/api/src/channel/helper/addObjectForm.ts
+++ b/server/apps/api/src/channel/helper/addObjectForm.ts
@@ -1,5 +1,5 @@
-export function getChannelToUserForm(communityId, channelId) {
+export function getChannelToUserForm(community_id, channel_id) {
   return {
-    [`communities.${communityId.toString()}.channels.${channelId.toString()}`]: new Date(),
+    [`communities.${community_id.toString()}.channels.${channel_id.toString()}`]: new Date(),
   };
 }

--- a/server/dao/schemas/user.schema.ts
+++ b/server/dao/schemas/user.schema.ts
@@ -41,7 +41,7 @@ export class User {
   @IsString()
   description: string;
 
-  @Prop({ default: 'ONLINE' })
+  @Prop({ default: 'OFFLINE' })
   @IsString()
   @IsIn(STATUS)
   status: string;


### PR DESCRIPTION
## Issues
- #124 
- #181 
- #187 

## 🤷‍♂️ Description

- auth: 버그 수정 및 에러 발생 시 로그로 출력되게 수정
- channel: 대규모 리펙토링 (내용은 아래와 같음)

## 📝 Primary Commits


>**버그 수정**
- 사용자 회원가입 시 STATUS가 `OFFLINE` 으로 설정
- 사용자 로그인 시 STATUS가 `ONLINE` 으로 변환
- 사용자 로그아웃 시 STATUS가 `OFFLINE` 으로 변환
- 관리자가 채널 탈퇴 시
  - 채널 user가 2명 이상 -> error 처리
  - 채널 user가 1명 -> 채널 삭제
- 채널 삭제 시 community에서 채널 삭제 로직 누락된거 수정

>**리펙토링**
- REST API 네이밍 규칙에 따라 API URL 수정
- 일관성을 위한 변수명 수정
- API URL 수정에 따라 `channel.controller` -> `channel.controller`, `channels.controller` 로 분리
- service에서 코드 간결화를 위해 dto로 받은 거 변수로 저장해서 사용
 
## 📒 Remarks

제가 API URL을 잘 못 짰다는 것을 어제 공부해서 알게되었습니다 ㅠㅠ (지적해주셔서 감사합니다!)
API URL 변경에 따른 혼란을 줘서 죄송합니다 🙇‍♂️🙇‍♂️