### PR TITLE
[CLIENT] 채팅방 무한 스크롤 적용

### DIFF
--- a/client/src/apis/chat.ts
+++ b/client/src/apis/chat.ts
@@ -1,8 +1,34 @@
+import type { SuccessResponse } from '@@types/apis/response';
+
+import { tokenAxios } from '@utils/axios';
+
+export type ChatType = 'TEXT' | 'IMAGE';
+
 export interface Chat {
-  _id: string;
+  id: string;
+  type: ChatType;
   content: string;
   senderId: string;
   updatedAt: string;
   createdAt: string;
   deletedAt: string;
 }
+
+export type GetChatsResult = {
+  chats: Chat[];
+  prev?: number;
+};
+
+export type GetChatsResponse = SuccessResponse<GetChatsResult>;
+export type GetChats = (
+  channelId: string,
+  prev?: number,
+) => Promise<GetChatsResult>;
+
+export const getChats: GetChats = (channelId, prev) => {
+  const endPoint = `/api/chat/${channelId}`;
+
+  return tokenAxios
+    .get<GetChatsResponse>(endPoint, { params: { prev } })
+    .then((response) => response.data.result);
+};

--- a/client/src/components/ChannelMetadata/index.tsx
+++ b/client/src/components/ChannelMetadata/index.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 
 import ChannelItem from '@components/ChannelItem';
 import RoomMetadata from '@components/RoomMetadata';
-import { formatDate } from '@utils/date';
+import { dateStringToKRLocaleDateString } from '@utils/date';
 import React from 'react';
 
 interface Props {
@@ -33,7 +33,7 @@ const ChannelMetadata: FC<Props> = ({
         </div>
         <div>
           <span className="font-bold">@{managerName}</span>님이 이 채널을{' '}
-          {formatDate(createdAt)}에 생성했습니다.
+          {dateStringToKRLocaleDateString(createdAt)}에 생성했습니다.
         </div>
       </div>
     </RoomMetadata>

--- a/client/src/components/ChannelMetadata/index.tsx
+++ b/client/src/components/ChannelMetadata/index.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 import ChannelItem from '@components/ChannelItem';
 import RoomMetadata from '@components/RoomMetadata';
 import { dateStringToKRLocaleDateString } from '@utils/date';
-import React from 'react';
+import React, { memo } from 'react';
 
 interface Props {
   profileUrl?: string;
@@ -40,4 +40,4 @@ const ChannelMetadata: FC<Props> = ({
   );
 };
 
-export default ChannelMetadata;
+export default memo(ChannelMetadata);

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -3,7 +3,7 @@ import type { ComponentPropsWithoutRef, FC } from 'react';
 
 import Avatar from '@components/Avatar';
 import { useUserQuery } from '@hooks/user';
-import { formatDate } from '@utils/date';
+import { dateStringToKRLocaleDateString } from '@utils/date';
 import React from 'react';
 
 interface Props extends ComponentPropsWithoutRef<'li'> {
@@ -32,13 +32,21 @@ const ChatItem: FC<Props> = ({ className = '', chat, isSystem = false }) => {
           <div>
             <div className="flex gap-2 items-center text-s16">
               <span
-                className={`font-bold ${isSystem ? 'text-primary' : 'text-indigo'
-                  }`}
+                className={
+                  /* format 방지용 */ `font-bold ${
+                    /* format 방지용 */ isSystem
+                    ? 'text-primary'
+                    : 'text-indigo'
+                  }`
+                }
               >
                 {userQuery.data.nickname}
               </span>
               <span className="text-placeholder">
-                {formatDate(createdAt, { hour: 'numeric', minute: 'numeric' })}
+                {dateStringToKRLocaleDateString(createdAt, {
+                  hour: 'numeric',
+                  minute: 'numeric',
+                })}
               </span>
               {deletedAt.length ? (
                 <span className="text-label">(삭제됨)</span>

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -4,7 +4,7 @@ import type { ComponentPropsWithoutRef, FC } from 'react';
 import Avatar from '@components/Avatar';
 import { useUserQuery } from '@hooks/user';
 import { dateStringToKRLocaleDateString } from '@utils/date';
-import React from 'react';
+import React, { memo } from 'react';
 
 interface Props extends ComponentPropsWithoutRef<'li'> {
   className?: string;
@@ -64,4 +64,4 @@ const ChatItem: FC<Props> = ({ className = '', chat, isSystem = false }) => {
   );
 };
 
-export default ChatItem;
+export default memo(ChatItem);

--- a/client/src/components/DMMetadata/index.tsx
+++ b/client/src/components/DMMetadata/index.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react';
 
 import ChannelItem from '@components/ChannelItem';
 import RoomMetadata from '@components/RoomMetadata';
-import { formatDate } from '@utils/date';
+import { dateStringToKRLocaleDateString } from '@utils/date';
 import React from 'react';
 
 interface Props {
@@ -29,7 +29,7 @@ const DMMetadata: FC<Props> = ({
         </div>
         <div>
           <span className="font-bold">@{creatorName}</span>님이 이 채널을{' '}
-          {formatDate(createdAt)}에 생성했습니다.
+          {dateStringToKRLocaleDateString(createdAt)}에 생성했습니다.
         </div>
       </div>
     </RoomMetadata>

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -1,0 +1,20 @@
+import type { GetChatsResult } from '@apis/chat';
+import type { AxiosError } from 'axios';
+
+import { getChats } from '@apis/chat';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import queryKeyCreator from '@/queryKeyCreator';
+
+export const useChatsInfiniteQuery = (channelId: string) => {
+  const key = queryKeyCreator.chat.list(channelId);
+  const infiniteQuery = useInfiniteQuery<GetChatsResult, AxiosError>(
+    key,
+    ({ pageParam = -1 }) => getChats(channelId, pageParam),
+    {
+      getPreviousPageParam: (firstPage) => firstPage.prev,
+    },
+  );
+
+  return infiniteQuery;
+};

--- a/client/src/hooks/useIsIntersecting.ts
+++ b/client/src/hooks/useIsIntersecting.ts
@@ -1,0 +1,28 @@
+import type { RefObject } from 'react';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+export const useIsIntersecting = <T extends HTMLElement>(
+  targetRef: RefObject<T>,
+) => {
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  useEffect(() => {
+    if (!targetRef.current) return;
+
+    if (!observerRef.current) {
+      observerRef.current = new IntersectionObserver((entries) =>
+        setIsIntersecting(entries.some((entry) => entry.isIntersecting)),
+      );
+    }
+
+    observerRef.current.observe(targetRef.current);
+
+    /* eslint-disable consistent-return */
+    return () => observerRef?.current?.disconnect();
+  }, [targetRef.current]);
+  return isIntersecting;
+};
+
+export default useIsIntersecting;

--- a/client/src/mocks/data/chats.js
+++ b/client/src/mocks/data/chats.js
@@ -1,0 +1,13 @@
+import { faker } from '@faker-js/faker';
+
+export const createMockChat = () => ({
+  id: faker.datatype.uuid(),
+  type: 'TEXT',
+  content: faker.lorem.sentences(),
+  senderId: faker.datatype.uuid(),
+  updatedAt: '',
+  createdAt: new Date().toISOString(),
+  deletedAt: '',
+});
+
+export const chats = [...Array(20)].map(createMockChat);

--- a/client/src/mocks/handlers/Chat.js
+++ b/client/src/mocks/handlers/Chat.js
@@ -1,0 +1,44 @@
+import { API_URL } from '@constants/url';
+import { rest } from 'msw';
+
+import { createMockChat } from '../data/chats';
+import {
+  createErrorContext,
+  createSuccessContext,
+} from '../utils/createContext';
+
+const BASE_URL = `${API_URL}/api`;
+
+const MAX_PREVIOUS_PAGE = 2;
+const GetChats = rest.get(`${BASE_URL}/chat/:channelId`, (req, res, ctx) => {
+  // const { channelId } = req.params;
+  const prev = Number(req.url.searchParams.get('prev'));
+  // const nextCursor = req.url.searchParams.get('next');
+
+  const ERROR = false;
+
+  // prevCursor가 undefined이거나 0이면 그대로 undefined를 반환한다.
+  // prevCursor가 -1이면 첫 요청이라는 뜻이므로 최대 페이지 개수를 반환한다.
+  // 그렇지 않으면 prevCursor를 1 줄여 보낸다.
+  const newPrevCursor =
+    isNaN(prev) || prev === 0
+      ? undefined
+      : prev === -1
+      ? MAX_PREVIOUS_PAGE
+      : prev - 1;
+
+  console.log(newPrevCursor);
+  const errorResponse = res(...createErrorContext(ctx));
+  const successResponse = res(
+    ...createSuccessContext(ctx, 200, 1000, {
+      prev: newPrevCursor,
+      chats: Number.isInteger(newPrevCursor)
+        ? [...Array(10)].map(createMockChat)
+        : [],
+    }),
+  );
+
+  return ERROR ? errorResponse : successResponse;
+});
+
+export default [GetChats];

--- a/client/src/mocks/handlers/index.js
+++ b/client/src/mocks/handlers/index.js
@@ -1,5 +1,6 @@
 import AuthHandlers from './Auth';
 import ChannelHandlers from './Channel';
+import ChatHandlers from './Chat';
 import CommunityHandlers from './Community';
 import DMHandlers from './DM';
 import FriendHandlers from './Friend';
@@ -12,4 +13,5 @@ export const handlers = [
   ...DMHandlers,
   ...CommunityHandlers,
   ...ChannelHandlers,
+  ...ChatHandlers,
 ];

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -35,8 +35,9 @@ const chatList = [
 ];
 
 const Channel = () => {
-  const { roomId } = useParams();
-  const { channelQuery } = useChannelQuery(roomId as string);
+  const params = useParams();
+  const roomId = params.roomId as string;
+  const { channelQuery } = useChannelQuery(roomId);
   const { userQuery } = useUserQuery(channelQuery.data?.managerId as string, {
     enabled: !!channelQuery.data?.managerId,
   });

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -30,6 +30,11 @@ const channelQueryKey = {
     [...channelQueryKey.all(), 'detail', channelId] as const,
 };
 
+const chatQueryKey = {
+  all: () => ['chats'] as const,
+  list: (channelId: string) => [...chatQueryKey.all(), { channelId }] as const,
+};
+
 const queryKeyCreator = {
   me: () => ['me'] as const,
   signUp: () => ['signUp'] as const,
@@ -42,6 +47,7 @@ const queryKeyCreator = {
   community: communityQueryKey,
   channel: channelQueryKey,
   user: userQueryKey,
+  chat: chatQueryKey,
 } as const;
 
 export default queryKeyCreator;

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -1,4 +1,4 @@
-export const formatDate = (
+export const dateStringToKRLocaleDateString = (
   str: string,
   options: Intl.DateTimeFormatOptions = {},
 ) =>


### PR DESCRIPTION
## Issues
- #183 

## 🤷‍♂️ Description

- 사용자가 스크롤을 위로 올리면 이전 메시지를 받아오는 무한 스크롤을 적용하였음.
- 채팅 메시지 항목들 가장 위에 Intersection Observer에 의해 관찰되는 `<div />` 요소를 끼워놓고, 해당 요소가 view port에 노출되면 이전 페이지들을 fetch해오는 방식임.


## 📝 Primary Commits

- [X] Intersection Observer API를 사용하여 `useIsIntersecting` 훅 작성
- [X] 채팅 메시지를 커서 기반 페이지네이션처럼 불러오는 mock API 작성 
- [X] 위로 스크롤 시 채팅 메시지 불러오는 무한 스크롤 적용


## 📷 Screenshots


![Animation](https://user-images.githubusercontent.com/57662010/204754298-9ab98561-3d42-4dd7-8721-0e569b14eb44.gif)

 
## 📒 Remarks

- 채팅방 들어가자마자 요소가 노출되어 fetch해옴 =>**첫번째 페이지 렌더링 후 스크롤을 아래로 내려 요소가 노출되지 않도록 해야함**