### PR TITLE
[Server/channel join] 채널 접속 API

### DIFF
--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -51,7 +51,7 @@ export class ChannelService {
       _id: channel_id,
       managerId: requestUserId,
     });
-    if (channel === undefined) {
+    if (!channel) {
       throw new UnauthorizedException('채널 관리자가 아닙니다.');
     }
 

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -6,6 +6,7 @@ import {
   CreateChannelDto,
   DeleteChannelDto,
   InviteChannelDto,
+  JoinChannelDto,
   ModifyChannelDto,
   UpdateLastReadDto,
 } from '@channel/dto';
@@ -148,7 +149,6 @@ export class ChannelService {
 
   async inviteChannel(inviteChannelDto: InviteChannelDto) {
     const { community_id, channel_id, users } = inviteChannelDto;
-    // 유저 도큐먼트의 커뮤니티:채널 필드 업데이트
     await this.addUserToChannel(community_id, channel_id, users);
   }
 
@@ -170,5 +170,10 @@ export class ChannelService {
       }),
     );
     return result;
+  }
+
+  async joinChannel(joinChannelDto: JoinChannelDto) {
+    const { requestUserId, channel_id, community_id } = joinChannelDto;
+    await this.addUserToChannel(community_id, channel_id, [requestUserId]);
   }
 }

--- a/server/apps/api/src/channel/channels.controller.ts
+++ b/server/apps/api/src/channel/channels.controller.ts
@@ -119,4 +119,17 @@ export class ChannelsController {
       throw error;
     }
   }
+
+  @Post(':channel_id')
+  @UseGuards(JwtAccessGuard)
+  async joinChannel(@Param('channel_id') channel_id, @Body() { community_id }, @Req() req: any) {
+    const requestUserId = req.user._id;
+    try {
+      await this.channelService.joinChannel({ requestUserId, channel_id, community_id });
+      return responseForm(200, { message: '채널 접속 성공!' });
+    } catch (error) {
+      this.logger.error(JSON.stringify(error.response));
+      throw error;
+    }
+  }
 }

--- a/server/apps/api/src/channel/dto/index.ts
+++ b/server/apps/api/src/channel/dto/index.ts
@@ -4,3 +4,4 @@ export * from './exit-channel.dto';
 export * from './delete-channel.dto';
 export * from './invite-channel.dto';
 export * from './update-last-read.dto';
+export * from './join-channel.dto';

--- a/server/apps/api/src/channel/dto/join-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/join-channel.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class JoinChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  requestUserId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  channel_id: string;
+
+  @IsString()
+  @IsNotEmpty()
+  community_id: string;
+}

--- a/server/apps/api/src/channel/dto/modify-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/modify-channel.dto.ts
@@ -22,4 +22,8 @@ export class ModifyChannelDto {
   @IsOptional()
   @Transform(({ value }) => value === 'true')
   isPrivate: boolean;
+
+  @IsString()
+  @IsOptional()
+  managerId: string;
 }


### PR DESCRIPTION
## Issues
- #195 

## 🤷‍♂️ Description

커뮤니티 사용자는 공개 채널에 참여할 수 있다.

채널 정보 수정 시, 매니저 ID 수정이 누락 된 버그 수정

## 📝 Primary Commits
- [x]  channels.controller
    - `POST api/channels/:channel_id`
    - `UseGuards(JwtAccessGuard)`
    - joinChannel
- [x]  channels.service
    - channel 도큐먼트의 users 필드 업데이트
    - user 도큐먼트의 community:channel 필드 업데이트

## 📷 Screenshots
<img width="406" alt="스크린샷 2022-11-30 오후 8 04 50" src="https://user-images.githubusercontent.com/72093196/204780086-48493ebe-3463-476b-bdb9-65d91f7f169a.png">

 