### PR TITLE
[CLIENT] GET `/api/users/:userId` API 사용하던 부분 GET `/api/channels/:channelId/usrs` API 사용하도록 변경

### DIFF
--- a/client/src/apis/channel.ts
+++ b/client/src/apis/channel.ts
@@ -1,5 +1,5 @@
 import type { SuccessResponse } from '@@types/apis/response';
-import type { UserUID } from '@apis/user';
+import type { User, UserUID } from '@apis/user';
 
 import { tokenAxios } from '@utils/axios';
 
@@ -16,7 +16,7 @@ export interface JoinedChannel {
 
 export interface Channel extends JoinedChannel {
   communityId: string;
-  users: Array<UserUID>;
+  users: User[];
   chatLists: [];
   createdAt: string;
   updatedAt: string;

--- a/client/src/apis/chat.ts
+++ b/client/src/apis/chat.ts
@@ -15,7 +15,7 @@ export interface Chat {
 }
 
 export type GetChatsResult = {
-  chats: Chat[];
+  chat: Chat[];
   prev?: number;
 };
 

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -100,18 +100,3 @@ export const getCommunityUsers: GetCommunityUsers = (communityId) => {
     .get<GetCommunityUsersResponse>(endPoint)
     .then((response) => response.data.result.users);
 };
-
-export interface GetChannelUsersResult {
-  users: User[];
-}
-
-export type GetChannelUsersResponse = SuccessResponse<GetChannelUsersResult>;
-export type GetChannelUsers = (channelId: string) => Promise<User[]>;
-
-export const getChannelUsers: GetChannelUsers = (channelId) => {
-  const endPoint = `/api/channels/${channelId}/users`;
-
-  return tokenAxios
-    .get<GetChannelUsersResponse>(endPoint)
-    .then((response) => response.data.result.users);
-};

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -86,21 +86,6 @@ export const getUsers: GetUsers = (params) => {
     .then((response) => response.data.result);
 };
 
-export type GetUserResult = User;
-export type GetUserResponse = SuccessResponse<GetUserResult>;
-export type GetUser = (userId: string) => Promise<GetUserResult>;
-
-/**
- * 유저 한명의 정보 얻기
- */
-export const getUser: GetUser = (userId) => {
-  const endPoint = `/api/user/${userId}`;
-
-  return tokenAxios
-    .get<GetUserResponse>(endPoint)
-    .then((response) => response.data.result);
-};
-
 export interface GetCommunityUsersResult {
   users: User[];
 }

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -115,3 +115,18 @@ export const getCommunityUsers: GetCommunityUsers = (communityId) => {
     .get<GetCommunityUsersResponse>(endPoint)
     .then((response) => response.data.result.users);
 };
+
+export interface GetChannelUsersResult {
+  users: User[];
+}
+
+export type GetChannelUsersResponse = SuccessResponse<GetChannelUsersResult>;
+export type GetChannelUsers = (channelId: string) => Promise<User[]>;
+
+export const getChannelUsers: GetChannelUsers = (channelId) => {
+  const endPoint = `/api/channels/${channelId}/users`;
+
+  return tokenAxios
+    .get<GetChannelUsersResponse>(endPoint)
+    .then((response) => response.data.result.users);
+};

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -59,16 +59,19 @@ export const updateFollowing: UpdateFollowing = (userId) => {
     .then((res) => res.data.result);
 };
 
-export type GetFollowersResult = User[];
+type Followers = User[];
+export type GetFollowersResult = {
+  followers: Followers;
+};
 export type GetFollowersResponse = SuccessResponse<GetFollowersResult>;
-export type GetFollowers = () => Promise<GetFollowersResult>;
+export type GetFollowers = () => Promise<Followers>;
 
 export const getFollowers: GetFollowers = () => {
   const endPoint = `/api/user/followers`;
 
   return tokenAxios
     .get<GetFollowersResponse>(endPoint)
-    .then((res) => res.data.result);
+    .then((res) => res.data.result.followers);
 };
 
 export interface GetUsersParams {

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -28,16 +28,19 @@ export const getMyInfo: GetMyInfo = () => {
     .then((response) => response.data.result);
 };
 
-export type GetFollowingsResult = User[];
+type Followings = User[];
+export interface GetFollowingsResult {
+  followings: Followings;
+}
 export type GetFollowingsResponse = SuccessResponse<GetFollowingsResult>;
-export type GetFollowings = () => Promise<GetFollowingsResult>;
+export type GetFollowings = () => Promise<Followings>;
 
 export const getFollowings: GetFollowings = () => {
   const endPoint = `/api/user/followings`;
 
   return tokenAxios
     .get<GetFollowingsResponse>(endPoint)
-    .then((res) => res.data.result);
+    .then((res) => res.data.result.followings);
 };
 
 export interface UpdateFollowingResult {

--- a/client/src/apis/user.ts
+++ b/client/src/apis/user.ts
@@ -77,9 +77,11 @@ export const getFollowers: GetFollowers = () => {
 export interface GetUsersParams {
   search: string;
 }
-export type GetUsersResult = User[];
+export type GetUsersResult = {
+  users: User[];
+};
 export type GetUsersResponse = SuccessResponse<GetUsersResult>;
-export type GetUsers = (params: GetUsersParams) => Promise<GetUsersResult>;
+export type GetUsers = (params: GetUsersParams) => Promise<User[]>;
 
 /**
  * 여러 유저 검색에 사용됨
@@ -89,7 +91,7 @@ export const getUsers: GetUsers = (params) => {
 
   return tokenAxios
     .get<GetUsersResponse>(endPoint, { params })
-    .then((response) => response.data.result);
+    .then((response) => response.data.result.users);
 };
 
 export interface GetCommunityUsersResult {

--- a/client/src/components/ChannelMetadata/index.tsx
+++ b/client/src/components/ChannelMetadata/index.tsx
@@ -1,3 +1,4 @@
+import type { Channel } from '@apis/channel';
 import type { FC } from 'react';
 
 import ChannelName from '@components/ChannelName';
@@ -6,20 +7,16 @@ import { dateStringToKRLocaleDateString } from '@utils/date';
 import React, { memo } from 'react';
 
 interface Props {
-  profileUrl?: string;
-  channelName: string;
-  isPrivate: boolean;
-  createdAt: string;
-  managerName: string;
+  channel: Channel;
+  managerName?: string;
 }
 
 const ChannelMetadata: FC<Props> = ({
-  profileUrl,
-  managerName,
-  channelName,
-  isPrivate,
-  createdAt,
+  channel,
+  managerName = '(알수없음)',
 }) => {
+  const { profileUrl, name: channelName, isPrivate, createdAt } = channel;
+
   return (
     <RoomMetadata profileUrl={profileUrl} channelName={channelName}>
       <div className="flex flex-col justify-center h-full">

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -1,65 +1,65 @@
 import type { Chat } from '@apis/chat';
+import type { User } from '@apis/user';
 import type { ComponentPropsWithoutRef, FC } from 'react';
 
 import Avatar from '@components/Avatar';
-import { useUserQuery } from '@hooks/user';
 import { dateStringToKRLocaleDateString } from '@utils/date';
 import React, { memo } from 'react';
 
 interface Props extends ComponentPropsWithoutRef<'li'> {
   className?: string;
   chat: Chat;
+  user?: User;
   isSystem?: boolean;
 }
 
-const ChatItem: FC<Props> = ({ className = '', chat, isSystem = false }) => {
-  const { content, senderId, updatedAt, createdAt, deletedAt } = chat;
-  const { userQuery } = useUserQuery(senderId);
+const ChatItem: FC<Props> = ({
+  className = '',
+  chat,
+  user = {
+    profileUrl: undefined,
+    nickname: '(알수없음)',
+  },
+  isSystem = false,
+}) => {
+  const { content, updatedAt, createdAt, deletedAt } = chat;
 
-  if (userQuery.isLoading) return <div></div>;
   return (
     <li className={className}>
-      {userQuery.data && (
-        <div className="flex gap-3">
-          <div className="pt-1">
-            <Avatar
-              variant="rectangle"
-              size="small"
-              url={userQuery.data.profileUrl}
-              name={userQuery.data.nickname}
-            />
-          </div>
-          <div>
-            <div className="flex gap-2 items-center text-s16">
-              <span
-                className={
-                  /* format 방지용 */ `font-bold ${
-                    /* format 방지용 */ isSystem
-                    ? 'text-primary'
-                    : 'text-indigo'
-                  }`
-                }
-              >
-                {userQuery.data.nickname}
-              </span>
-              <span className="text-placeholder">
-                {dateStringToKRLocaleDateString(createdAt, {
-                  hour: 'numeric',
-                  minute: 'numeric',
-                })}
-              </span>
-              {deletedAt.length ? (
-                <span className="text-label">(삭제됨)</span>
-              ) : updatedAt.length ? (
-                <span className="text-label">(수정됨)</span>
-              ) : (
-                ''
-              )}
-            </div>
-            <div>{deletedAt.length ? '삭제된 메시지입니다' : content}</div>
-          </div>
+      <div className="flex gap-3">
+        <div className="pt-1">
+          <Avatar
+            variant="rectangle"
+            size="small"
+            url={user.profileUrl}
+            name={user.nickname}
+          />
         </div>
-      )}
+        <div>
+          <div className="flex gap-2 items-center text-s16">
+            <span
+              className={`font-bold ${isSystem ? 'text-primary' : 'text-indigo'
+                }`}
+            >
+              {user.nickname}
+            </span>
+            <span className="text-placeholder">
+              {dateStringToKRLocaleDateString(createdAt, {
+                hour: 'numeric',
+                minute: 'numeric',
+              })}
+            </span>
+            {deletedAt.length ? (
+              <span className="text-label">(삭제됨)</span>
+            ) : updatedAt.length ? (
+              <span className="text-label">(수정됨)</span>
+            ) : (
+              ''
+            )}
+          </div>
+          <div>{deletedAt.length ? '삭제된 메시지입니다' : content}</div>
+        </div>
+      </div>
     </li>
   );
 };

--- a/client/src/constants/endPoint.ts
+++ b/client/src/constants/endPoint.ts
@@ -17,8 +17,6 @@ const endPoint = {
   getUsers: () => `/api/users`, // 사용할 때는 queryString 추가 전달 필요합니다.
   getCommunityUsers: (communityId: string) =>
     `/api/communities/${communityId}/users`,
-  getChannelUsers: (channelId: string) =>
-    `/api/channels/${channelId}/users` /* 삭제해야함*/,
 } as const;
 
 export default endPoint;

--- a/client/src/constants/endPoint.ts
+++ b/client/src/constants/endPoint.ts
@@ -17,6 +17,8 @@ const endPoint = {
   getUsers: () => `/api/users`, // 사용할 때는 queryString 추가 전달 필요합니다.
   getCommunityUsers: (communityId: string) =>
     `/api/communities/${communityId}/users`,
+  getChannelUsers: (channelId: string) =>
+    `/api/channels/${channelId}/users` /* 삭제해야함*/,
 } as const;
 
 export default endPoint;

--- a/client/src/hooks/user.ts
+++ b/client/src/hooks/user.ts
@@ -1,29 +1,10 @@
-import type { User, GetChannelUsersResult } from '@apis/user';
+import type { GetChannelUsersResult, User } from '@apis/user';
 import type { AxiosError } from 'axios';
 
-import { getChannelUsers, getCommunityUsers, getUser } from '@apis/user';
+import { getChannelUsers, getCommunityUsers } from '@apis/user';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
 
 import queryKeyCreator from '@/queryKeyCreator';
-
-export const useUserQuery = (
-  userId: string,
-  options?: {
-    enabled?: boolean;
-  },
-) => {
-  const queryClient = useQueryClient();
-  const key = queryKeyCreator.user.detail(userId);
-
-  const query = useQuery(key, () => getUser(userId), options);
-  const invalidate = useCallback(
-    () => queryClient.invalidateQueries(key),
-    [queryClient, key],
-  );
-
-  return { userQuery: query, invalidateUserQuery: invalidate };
-};
 
 export const useCommunityUsersQuery = (communityId: string) => {
   const key = queryKeyCreator.user.communityUsers(communityId);

--- a/client/src/hooks/user.ts
+++ b/client/src/hooks/user.ts
@@ -1,7 +1,7 @@
-import type { GetChannelUsersResult, User } from '@apis/user';
+import type { User } from '@apis/user';
 import type { AxiosError } from 'axios';
 
-import { getChannelUsers, getCommunityUsers } from '@apis/user';
+import { getCommunityUsers } from '@apis/user';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import queryKeyCreator from '@/queryKeyCreator';
@@ -24,24 +24,4 @@ export const useInvalidateCommunityUsersQuery = (communityId: string) => {
     queryClient.invalidateQueries(key);
 
   return { invalidateCommunityUsersQuery };
-};
-
-export const useChannelUsersQuery = (
-  channelId: string,
-  options?: {
-    select?: (
-      users: GetChannelUsersResult['users'],
-    ) => GetChannelUsersResult['users'];
-    enabled?: boolean;
-  },
-) => {
-  const key = queryKeyCreator.user.channelUsers(channelId);
-
-  const query = useQuery<GetChannelUsersResult['users'], AxiosError>(
-    key,
-    () => getChannelUsers(channelId),
-    options,
-  );
-
-  return query;
 };

--- a/client/src/hooks/user.ts
+++ b/client/src/hooks/user.ts
@@ -1,7 +1,7 @@
 import type { User } from '@apis/user';
 import type { AxiosError } from 'axios';
 
-import { getCommunityUsers, getUser } from '@apis/user';
+import { getChannelUsers, getCommunityUsers } from '@apis/user';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -43,4 +43,25 @@ export const useInvalidateCommunityUsersQuery = (communityId: string) => {
     queryClient.invalidateQueries(key);
 
   return { invalidateCommunityUsersQuery };
+};
+
+// TODO: `options` any 타입 바꾸기
+export const useChannelUsersQuery = (
+  channelId: string,
+  options?: {
+    select?: (
+      users: GetChannelUsersResult['users'],
+    ) => GetChannelUsersResult['users'];
+    enabled?: boolean;
+  },
+) => {
+  const key = queryKeyCreator.user.channelUsers(channelId);
+
+  const query = useQuery<GetChannelUsersResult['users'], AxiosError>(
+    key,
+    () => getChannelUsers(channelId),
+    options,
+  );
+
+  return query;
 };

--- a/client/src/hooks/user.ts
+++ b/client/src/hooks/user.ts
@@ -1,7 +1,7 @@
-import type { User } from '@apis/user';
+import type { User, GetChannelUsersResult } from '@apis/user';
 import type { AxiosError } from 'axios';
 
-import { getChannelUsers, getCommunityUsers } from '@apis/user';
+import { getChannelUsers, getCommunityUsers, getUser } from '@apis/user';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
@@ -45,7 +45,6 @@ export const useInvalidateCommunityUsersQuery = (communityId: string) => {
   return { invalidateCommunityUsersQuery };
 };
 
-// TODO: `options` any 타입 바꾸기
 export const useChannelUsersQuery = (
   channelId: string,
   options?: {

--- a/client/src/layouts/DmNav/index.tsx
+++ b/client/src/layouts/DmNav/index.tsx
@@ -1,12 +1,14 @@
-import DirectMessageUserItem from '@components/DirectMessageUserItem';
-import useDirectMessagesQuery from '@hooks/useDirectMessagesQuery';
+import UserProfile from '@components/UserProfile';
+import { faker } from '@faker-js/faker';
 import { useMyInfo } from '@hooks/useMyInfoQuery';
+import { useChannelUsersQuery } from '@hooks/user';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
 const DmNav = () => {
-  const myInfo = useMyInfo();
-  const directMessagesQuery = useDirectMessagesQuery();
+  // const myInfo = useMyInfo();
+  // TODO 현재 DM API 없는 관계로 임시로 channel의 사용자 목록 가져오는 API 사용함
+  const channelUsersQuery = useChannelUsersQuery('dm');
 
   return (
     <nav className="flex flex-col flex-1">
@@ -15,21 +17,15 @@ const DmNav = () => {
           <Link to="/dms">Direct Message</Link>
         </h2>
       </header>
-      {directMessagesQuery.isLoading ? (
+      {channelUsersQuery.isLoading ? (
         <div>loading...</div>
       ) : (
-        directMessagesQuery.data?.length && (
+        channelUsersQuery.data?.length && (
           <ul className="flex flex-col p-6 [&>*:hover]:rounded-md [&>*:hover]:bg-offWhite">
-            {directMessagesQuery.data.map((directMessage) => (
-              <li key={directMessage._id}>
-                <Link to={`/dms/${directMessage._id}`}>
-                  <DirectMessageUserItem
-                    userId={
-                      directMessage.users.filter(
-                        (uid) => uid !== myInfo?._id,
-                      )[0]
-                    }
-                  />
+            {channelUsersQuery.data.map((user) => (
+              <li key={user._id}>
+                <Link to={`/dms/${user._id}`}>
+                  <UserProfile user={user} />
                 </Link>
               </li>
             ))}

--- a/client/src/layouts/DmNav/index.tsx
+++ b/client/src/layouts/DmNav/index.tsx
@@ -1,14 +1,15 @@
 import UserProfile from '@components/UserProfile';
-import { faker } from '@faker-js/faker';
-import { useMyInfo } from '@hooks/useMyInfoQuery';
-import { useChannelUsersQuery } from '@hooks/user';
+import { useChannelQuery } from '@hooks/channel';
+// import { useMyInfo } from '@hooks/useMyInfoQuery';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
 const DmNav = () => {
   // const myInfo = useMyInfo();
   // TODO 현재 DM API 없는 관계로 임시로 channel의 사용자 목록 가져오는 API 사용함
-  const channelUsersQuery = useChannelUsersQuery('dm');
+  const { channelQuery } = useChannelQuery('dm');
+
+  if (channelQuery.isLoading) return <div>loading</div>;
 
   return (
     <nav className="flex flex-col flex-1">
@@ -17,12 +18,12 @@ const DmNav = () => {
           <Link to="/dms">Direct Message</Link>
         </h2>
       </header>
-      {channelUsersQuery.isLoading ? (
+      {channelQuery.isLoading ? (
         <div>loading...</div>
       ) : (
-        channelUsersQuery.data?.length && (
+        channelQuery.data && (
           <ul className="flex flex-col p-6 [&>*:hover]:rounded-md [&>*:hover]:bg-offWhite">
-            {channelUsersQuery.data.map((user) => (
+            {channelQuery.data.users.map((user) => (
               <li key={user._id}>
                 <Link to={`/dms/${user._id}`}>
                   <UserProfile user={user} />

--- a/client/src/mocks/data/chats.js
+++ b/client/src/mocks/data/chats.js
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker';
 
+import { users } from './users';
+
 export const createMockChat = () => ({
   id: faker.datatype.uuid(),
   type: 'TEXT',
   content: faker.lorem.sentences(),
-  senderId: faker.datatype.uuid(),
+  senderId: users[0]._id,
   updatedAt: '',
   createdAt: new Date().toISOString(),
   deletedAt: '',

--- a/client/src/mocks/data/communities.js
+++ b/client/src/mocks/data/communities.js
@@ -1,11 +1,11 @@
 import { faker } from '@faker-js/faker';
 
 import { chancify } from '../utils/rand';
-import { channelUsers } from './users';
+import { channelUsers, users } from './users';
 
 export const createMockChannel = () => ({
   _id: faker.datatype.uuid(),
-  managerId: faker.datatype.uuid(),
+  managerId: users[0]._id,
   name: faker.name.jobType(),
   isPrivate: chancify(() => true, 50, false),
   profileUrl: chancify(() => faker.image.avatar(), 50),
@@ -13,6 +13,7 @@ export const createMockChannel = () => ({
   lastRead: chancify(() => true, 50, false),
   type: 'Channel',
   users: channelUsers,
+  createdAt: new Date().toISOString(),
 });
 
 export const channels = [...Array(10)].map(createMockChannel);

--- a/client/src/mocks/data/communities.js
+++ b/client/src/mocks/data/communities.js
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import { chancify } from '../utils/rand';
+import { channelUsers } from './users';
 
 export const createMockChannel = () => ({
   _id: faker.datatype.uuid(),
@@ -11,6 +12,7 @@ export const createMockChannel = () => ({
   description: faker.lorem.sentence(1),
   lastRead: chancify(() => true, 50, false),
   type: 'Channel',
+  users: channelUsers,
 });
 
 export const channels = [...Array(10)].map(createMockChannel);

--- a/client/src/mocks/data/users.js
+++ b/client/src/mocks/data/users.js
@@ -14,3 +14,4 @@ export const createMockUser = () => ({
 export const users = [...Array(30)].map(createMockUser);
 export const me = users.at(0);
 export const communityUsers = users.slice(0, 10);
+export const channelUsers = users.slice(0, 10);

--- a/client/src/mocks/handlers/Channel.js
+++ b/client/src/mocks/handlers/Channel.js
@@ -20,6 +20,8 @@ const GetChannel = rest.get(getChannelEndPoint, (req, res, ctx) => {
     targetChannel = _channels.find(({ _id }) => _id === channelId);
   });
 
+  if (!targetChannel) targetChannel = communities[0].channels[0];
+
   const errorResponse = res(...createErrorContext(ctx));
   const successResponse = res(
     ...createSuccessContext(ctx, 200, 500, {

--- a/client/src/mocks/handlers/Chat.js
+++ b/client/src/mocks/handlers/Chat.js
@@ -32,7 +32,7 @@ const GetChats = rest.get(`${BASE_URL}/chat/:channelId`, (req, res, ctx) => {
   const successResponse = res(
     ...createSuccessContext(ctx, 200, 1000, {
       prev: newPrevCursor,
-      chats: Number.isInteger(newPrevCursor)
+      chat: Number.isInteger(newPrevCursor)
         ? [...Array(10)].map(createMockChat)
         : [],
     }),

--- a/client/src/mocks/handlers/Friend.js
+++ b/client/src/mocks/handlers/Friend.js
@@ -11,7 +11,9 @@ const GetFollowings = rest.get(getFollowingsEndPoint, (req, res, ctx) => {
     ctx.status(200),
     ctx.json({
       statusCode: 200,
-      result: users,
+      result: {
+        followings: users,
+      },
     }),
   );
 });
@@ -40,7 +42,9 @@ const GetFollowers = rest.get(getFollowersEndPoint, (req, res, ctx) => {
     ctx.status(200),
     ctx.json({
       statusCode: 200,
-      result: users,
+      result: {
+        followers: users,
+      },
     }),
   );
 });

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -46,17 +46,4 @@ const GetCommunityUsers = rest.get(
   },
 );
 
-const getChannelUsersEndPoint =
-  API_URL + endPoint.getChannelUsers(`:channelId`);
-const GetChannelUsers = rest.get(getChannelUsersEndPoint, (req, res, ctx) => {
-  const ERROR = false;
-
-  const errorResponse = res(...createErrorContext(ctx));
-  const successResponse = res(
-    ...createSuccessContext(ctx, 200, 500, { users: channelUsers }),
-  );
-
-  return ERROR ? errorResponse : successResponse;
-});
-
-export default [GetUsers, GetCommunityUsers, GetChannelUsers];
+export default [GetUsers, GetCommunityUsers];

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -2,7 +2,7 @@ import endPoint from '@constants/endPoint';
 import { API_URL } from '@constants/url';
 import { rest } from 'msw';
 
-import { communityUsers, channelUsers, users } from '../data/users';
+import { communityUsers, users } from '../data/users';
 import {
   createErrorContext,
   createSuccessContext,

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -27,16 +27,6 @@ const GetUsers = rest.get(getUsersEndPoint, (req, res, ctx) => {
   );
 });
 
-// TODO: 없는 메서드인데, 컴포넌트에서 사용중 (삭제해야합니다.)
-const GetUser = rest.get(`${API_URL}/api/user/:userId`, (req, res, ctx) => {
-  const ERROR = false;
-
-  const errorResponse = res(...createErrorContext(ctx));
-  const successResponse = res(...createSuccessContext(ctx, 200, 500, users[0]));
-
-  return ERROR ? errorResponse : successResponse;
-});
-
 const getCommunityUsersEndPoint =
   API_URL + endPoint.getCommunityUsers(':communityId');
 const GetCommunityUsers = rest.get(
@@ -69,4 +59,4 @@ const GetChannelUsers = rest.get(getChannelUsersEndPoint, (req, res, ctx) => {
   return ERROR ? errorResponse : successResponse;
 });
 
-export default [GetUsers, GetUser, GetCommunityUsers, GetChannelUsers];
+export default [GetUsers, GetCommunityUsers, GetChannelUsers];

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -56,18 +56,17 @@ const GetCommunityUsers = rest.get(
   },
 );
 
-const GetChannelUsers = rest.get(
-  `${BASE_URL}/channels/:channelId/users`,
-  (req, res, ctx) => {
-    const ERROR = false;
+const getChannelUsersEndPoint =
+  API_URL + endPoint.getChannelUsers(`:channelId`);
+const GetChannelUsers = rest.get(getChannelUsersEndPoint, (req, res, ctx) => {
+  const ERROR = false;
 
-    const errorResponse = res(...createErrorContext(ctx));
-    const successResponse = res(
-      ...createSuccessContext(ctx, 200, 500, { users: channelUsers }),
-    );
+  const errorResponse = res(...createErrorContext(ctx));
+  const successResponse = res(
+    ...createSuccessContext(ctx, 200, 500, { users: channelUsers }),
+  );
 
-    return ERROR ? errorResponse : successResponse;
-  },
-);
+  return ERROR ? errorResponse : successResponse;
+});
 
 export default [GetUsers, GetUser, GetCommunityUsers, GetChannelUsers];

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -18,11 +18,13 @@ const GetUsers = rest.get(getUsersEndPoint, (req, res, ctx) => {
     ctx.status(200),
     ctx.json({
       statusCode: 200,
-      result: users.filter(
-        (user) =>
-          user.id.toUpperCase().includes(search) ||
-          user.nickname.toUpperCase().includes(search),
-      ),
+      result: {
+        users: users.filter(
+          (user) =>
+            user.id.toUpperCase().includes(search) ||
+            user.nickname.toUpperCase().includes(search),
+        ),
+      },
     }),
   );
 });

--- a/client/src/mocks/handlers/User.js
+++ b/client/src/mocks/handlers/User.js
@@ -2,7 +2,7 @@ import endPoint from '@constants/endPoint';
 import { API_URL } from '@constants/url';
 import { rest } from 'msw';
 
-import { communityUsers, users } from '../data/users';
+import { communityUsers, channelUsers, users } from '../data/users';
 import {
   createErrorContext,
   createSuccessContext,
@@ -56,4 +56,18 @@ const GetCommunityUsers = rest.get(
   },
 );
 
-export default [GetUsers, GetUser, GetCommunityUsers];
+const GetChannelUsers = rest.get(
+  `${BASE_URL}/channels/:channelId/users`,
+  (req, res, ctx) => {
+    const ERROR = false;
+
+    const errorResponse = res(...createErrorContext(ctx));
+    const successResponse = res(
+      ...createSuccessContext(ctx, 200, 500, { users: channelUsers }),
+    );
+
+    return ERROR ? errorResponse : successResponse;
+  },
+);
+
+export default [GetUsers, GetUser, GetCommunityUsers, GetChannelUsers];

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -3,7 +3,6 @@ import ChatItem from '@components/ChatItem';
 import { useChannelQuery } from '@hooks/channel';
 import { useChatsInfiniteQuery } from '@hooks/chat';
 import useIsIntersecting from '@hooks/useIsIntersecting';
-import { useChannelUsersQuery } from '@hooks/user';
 import React, { useRef, useEffect, Fragment } from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
 import { useParams } from 'react-router-dom';
@@ -12,7 +11,6 @@ const Channel = () => {
   const params = useParams();
   const roomId = params.roomId as string;
   const { channelQuery } = useChannelQuery(roomId);
-  const channelUsersQuery = useChannelUsersQuery(roomId);
 
   // TODO: `any` 말고 적절한 타이핑 주기
   const scrollbarContainerRef = useRef<any>(null);
@@ -32,11 +30,7 @@ const Channel = () => {
     chatsInfiniteQuery.fetchPreviousPage();
   }, [isFetchPreviousIntersecting]);
 
-  if (
-    channelQuery.isLoading ||
-    channelUsersQuery.isLoading ||
-    chatsInfiniteQuery.isLoading
-  )
+  if (channelQuery.isLoading || chatsInfiniteQuery.isLoading)
     return <div>loading</div>;
 
   return (
@@ -56,38 +50,40 @@ const Channel = () => {
             <div ref={fetchPreviousRef} />
             <div>
               <ul className="flex flex-col gap-3 [&>*:hover]:bg-background">
-                {chatsInfiniteQuery.data?.pages.map((page) =>
-                  page.chats.length ? (
-                    <Fragment key={page.chats[0].id}>
-                      {page.chats.map((chat) => (
-                        <ChatItem
-                          key={chat.id}
-                          chat={chat}
-                          className="px-8"
-                          user={channelUsersQuery.data?.find(
-                            (user) => user._id === chat.senderId,
-                          )}
-                        />
-                      ))}
-                    </Fragment>
-                  ) : (
-                    <Fragment key={channelQuery.data?._id}>
-                      {channelQuery.data && channelUsersQuery.data && (
-                        <div className="p-8">
-                          <ChannelMetadata
-                            channel={channelQuery.data}
-                            managerName={
-                              channelUsersQuery.data?.find(
-                                (user) =>
-                                  user._id === channelQuery.data.managerId,
-                              )?.nickname
-                            }
+                {chatsInfiniteQuery.data &&
+                  channelQuery.data &&
+                  chatsInfiniteQuery.data.pages.map((page) =>
+                    page.chats.length ? (
+                      <Fragment key={page.chats[0].id}>
+                        {page.chats.map((chat) => (
+                          <ChatItem
+                            key={chat.id}
+                            chat={chat}
+                            className="px-8"
+                            user={channelQuery.data.users.find(
+                              (user) => user._id === chat.senderId,
+                            )}
                           />
-                        </div>
-                      )}
-                    </Fragment>
-                  ),
-                )}
+                        ))}
+                      </Fragment>
+                    ) : (
+                      <Fragment key={channelQuery.data._id}>
+                        {channelQuery.data && channelQuery.data.users && (
+                          <div className="p-8">
+                            <ChannelMetadata
+                              channel={channelQuery.data}
+                              managerName={
+                                channelQuery.data.users.find(
+                                  (user) =>
+                                    user._id === channelQuery.data.managerId,
+                                )?.nickname
+                              }
+                            />
+                          </div>
+                        )}
+                      </Fragment>
+                    ),
+                  )}
               </ul>
             </div>
           </Scrollbars>

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -53,9 +53,9 @@ const Channel = () => {
                 {chatsInfiniteQuery.data &&
                   channelQuery.data &&
                   chatsInfiniteQuery.data.pages.map((page) =>
-                    page.chats.length ? (
-                      <Fragment key={page.chats[0].id}>
-                        {page.chats.map((chat) => (
+                    page.chat.length ? (
+                      <Fragment key={page.chat[0].id}>
+                        {page.chat.map((chat) => (
                           <ChatItem
                             key={chat.id}
                             chat={chat}

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -1,7 +1,5 @@
 const userQueryKey = {
   all: () => ['users'] as const,
-  detail: (userId: string) =>
-    [...userQueryKey.all(), 'detail', userId] as const,
   communityUsers: (communityId: string) =>
     [...userQueryKey.all(), { communityId }] as const,
   channelUsers: (channelId: string) =>

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -4,6 +4,8 @@ const userQueryKey = {
     [...userQueryKey.all(), 'detail', userId] as const,
   communityUsers: (communityId: string) =>
     [...userQueryKey.all(), { communityId }] as const,
+  channelUsers: (channelId: string) =>
+    [...userQueryKey.all(), { channelId }] as const,
 };
 
 const directMessageQueryKey = {


### PR DESCRIPTION
## Issues
- #213

## 🤷‍♂️ Description

- GET `/api/users/:userId` API는 제공되지 않으므로 GET `/api/channels/:channelId/usrs` API를 사용하도록 변경
# ⚠️ 단, GET `/api/channels/:channelId/usrs` API도 사용하지 않을 예정임(현재 postman 명세에 있으니 대체함)⚠️
