### PR TITLE
[CLIENT] 팔로잉 탭 리팩토링, 컨텍스트 메뉴

### DIFF
--- a/client/src/components/FollowingUserContextMenu/index.tsx
+++ b/client/src/components/FollowingUserContextMenu/index.tsx
@@ -1,0 +1,43 @@
+import type { User } from '@apis/user';
+import type { FC } from 'react';
+
+import { UserMinusIcon } from '@heroicons/react/20/solid';
+import useFollowingMutation from '@hooks/useFollowingMutation';
+import { useRootStore } from '@stores/rootStore';
+import React from 'react';
+
+interface Props {
+  user: User;
+}
+
+const FollowingUserContextMenu: FC<Props> = ({ user }) => {
+  const closeContextMenuModal = useRootStore(
+    (state) => state.closeContextMenuModal,
+  );
+  const followingMutation = useFollowingMutation(user._id);
+  const unfollow = () => followingMutation.mutate(user);
+
+  const handleUnfollowButtonClick = async () => {
+    unfollow();
+    closeContextMenuModal(); /* TODO: 모달 안 닫히는 문제 있음 */
+  };
+
+  return (
+    <section className="w-[300px] p-[16px] rounded-[10px] border border-line">
+      <h3 className="sr-only">팔로잉 컨텍스트 메뉴</h3>
+      <ul>
+        <li>
+          <button
+            className="flex justify-between items-center w-full text-s16 h-[40px] rounded-xl hover:bg-background px-[12px] "
+            onClick={handleUnfollowButtonClick}
+          >
+            <span>언팔로우하기</span>
+            <UserMinusIcon className="w-6 h-6 pointer-events-none text-error" />
+          </button>
+        </li>
+      </ul>
+    </section>
+  );
+};
+
+export default FollowingUserContextMenu;

--- a/client/src/components/FollowingUserItem/index.tsx
+++ b/client/src/components/FollowingUserItem/index.tsx
@@ -1,12 +1,13 @@
 import type { User } from '@apis/user';
 import type { FC } from 'react';
 
+import FollowingUserContextMenu from '@components/FollowingUserContextMenu';
 import UserItem from '@components/UserItem';
 import {
   EllipsisHorizontalIcon,
   ChatBubbleLeftIcon,
 } from '@heroicons/react/20/solid';
-import useFollowingMutation from '@hooks/useFollowingMutation';
+import { useRootStore } from '@stores/rootStore';
 import React, { memo } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -15,8 +16,18 @@ interface Props {
 }
 
 const FollowingUserItem: FC<Props> = ({ user }) => {
-  const followingMutation = useFollowingMutation(user._id);
-  const { mutate: updateFollowing } = followingMutation;
+  const openCommonModal = useRootStore((state) => state.openCommonModal);
+
+  const handleMoreButtonClick: React.MouseEventHandler<HTMLButtonElement> = (
+    e,
+  ) => {
+    openCommonModal({
+      content: <FollowingUserContextMenu user={user} />,
+      overlayBackground: 'transparent',
+      x: e.clientX,
+      y: e.clientY,
+    });
+  };
 
   return (
     <UserItem
@@ -32,7 +43,7 @@ const FollowingUserItem: FC<Props> = ({ user }) => {
           </Link>
           <button
             className="p-2 rounded-full border border-line"
-            onClick={() => updateFollowing(user)}
+            onClick={handleMoreButtonClick}
           >
             <span className="sr-only">더보기</span>
             <EllipsisHorizontalIcon className="w-6 h-6 fill-indigo" />

--- a/client/src/components/FollowingUserSearchResult/index.tsx
+++ b/client/src/components/FollowingUserSearchResult/index.tsx
@@ -1,0 +1,36 @@
+import type { User } from '@apis/user';
+import type { FC } from 'react';
+
+import FollowingUserItem from '@components/FollowingUserItem';
+import UserList from '@components/UserList';
+import React from 'react';
+import Scrollbars from 'react-custom-scrollbars-2';
+
+interface Props {
+  users: User[];
+}
+
+/**
+ *
+ * @returns 팔로잉 목록을 렌더링하는 컴포넌트
+ */
+const FollowingUserSearchResult: FC<Props> = ({ users }) => {
+  if (!users.length) {
+    return (
+      <div className="w-full h-full flex justify-center items-center">
+        검색 결과가 없습니다.
+      </div>
+    );
+  }
+  return (
+    <Scrollbars>
+      <UserList>
+        {users.map((user) => (
+          <FollowingUserItem key={user._id} user={user} />
+        ))}
+      </UserList>
+    </Scrollbars>
+  );
+};
+
+export default FollowingUserSearchResult;

--- a/client/src/layouts/Followings/index.tsx
+++ b/client/src/layouts/Followings/index.tsx
@@ -1,10 +1,9 @@
-import FollowingUserItem from '@components/FollowingUserItem';
+import ErrorMessage from '@components/ErrorMessage';
+import FollowingUserSearchResult from '@components/FollowingUserSearchResult';
 import SearchInput from '@components/SearchInput';
-import UserList from '@components/UserList';
 import useDebouncedValue from '@hooks/useDebouncedValue';
 import useFollowingsQuery from '@hooks/useFollowingsQuery';
 import React, { useState } from 'react';
-import Scrollbars from 'react-custom-scrollbars-2';
 
 /**
  *
@@ -28,19 +27,15 @@ const Followings = () => {
           placeholder="검색하기"
         />
       </div>
-      <Scrollbars>
+      <div className="flex justify-center items-center w-full h-full">
         {followingsQuery.isLoading ? (
-          <div className="flex items-center justify-center">로딩중...</div>
-        ) : followingsQuery.data?.length ? (
-          <UserList>
-            {followingsQuery.data.map((user) => (
-              <FollowingUserItem key={user._id} user={user} />
-            ))}
-          </UserList>
+          <div>로딩중...</div>
+        ) : followingsQuery.isError ? (
+          <ErrorMessage size="lg">에러가 발생했습니다.</ErrorMessage>
         ) : (
-          '일치하는 사용자가 없습니다.'
+          <FollowingUserSearchResult users={followingsQuery.data} />
         )}
-      </Scrollbars>
+      </div>
     </div>
   );
 };

--- a/client/src/layouts/Followings/index.tsx
+++ b/client/src/layouts/Followings/index.tsx
@@ -6,6 +6,13 @@ import useFollowingsQuery from '@hooks/useFollowingsQuery';
 import React, { useState } from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
 
+/**
+ *
+ * @returns 검색 인풋과 팔로잉 목록을 렌더링하는 컴포넌트.
+ * 기본적으로는 사용자의 모든 팔로잉 목록을 렌더링하나,
+ * 사용자가 검색 인풋에 검색어를 입력하면 해당 값으로 필터링된 팔로잉 목록을 렌더링한다.
+ */
+
 const Followings = () => {
   const DEBOUNCE_DELAY = 500;
   const [filter, setFilter] = useState('');


### PR DESCRIPTION
## Issues
- #234
- #236 

## 🤷‍♂️ Description

<!-- 어떤 문제에 관한 PR인지 간략하게 적어주세요. -->


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 팔로잉 탭에서 팔로잉 목록만 렌더링하는 컴포넌트 분리
- [X] 팔로잉 컨텍스트 메뉴 추가


## 📷 Screenshots
![Animation](https://user-images.githubusercontent.com/57662010/205437036-2c2b1b81-b97f-4006-bae4-b5598c7c5da0.gif)


 
## 📒 Remarks

- 언팔로우 버튼 클릭시 모달 안 닫히는 문제 있음