### PR TITLE
[CLIENT] 안 읽은 메시지가 있으면 gnb 아이템과 채널 아이템에 표시

### DIFF
--- a/client/src/components/Badge/index.tsx
+++ b/client/src/components/Badge/index.tsx
@@ -1,11 +1,13 @@
 import type { FC } from 'react';
 
-import React from 'react';
+import React, { memo } from 'react';
 
 interface BadgeProps {
   children?: React.ReactNode;
   size?: 'small' | 'medium';
-  color?: 'success' | 'error' | 'default';
+  color?: 'success' | 'error' | 'default' | 'primary';
+  vertical?: 'top' | 'bottom';
+  horizontal?: 'right' | 'left';
 }
 
 const scale = {
@@ -17,21 +19,34 @@ const background = {
   success: 'bg-success',
   error: 'bg-error',
   default: 'bg-label',
+  primary: 'bg-indigo',
+};
+
+const verticalPosition = {
+  top: 'top-0',
+  bottom: 'bottom-0',
+};
+
+const horizontalPosition = {
+  right: 'right-0',
+  left: 'left-0',
 };
 
 const Badge: FC<BadgeProps> = ({
   children,
   size = 'small',
   color = 'default',
+  vertical = 'bottom',
+  horizontal = 'right',
 }) => {
   return (
     <div className={`relative`}>
       <div
-        className={`absolute bottom-0 right-0 rounded-full ${scale[size]} border-2 border-offWhite ${background[color]}`}
+        className={`absolute ${verticalPosition[vertical]} ${horizontalPosition[horizontal]} rounded-full ${scale[size]} border-2 border-offWhite ${background[color]}`}
       />
       {children}
     </div>
   );
 };
 
-export default Badge;
+export default memo(Badge);

--- a/client/src/components/ChannelItem/index.tsx
+++ b/client/src/components/ChannelItem/index.tsx
@@ -15,13 +15,18 @@ const ChannelItem: FC<Props> = ({ channel, communityId, ...restProps }) => {
     <li {...restProps}>
       <Link
         to={`/communities/${communityId}/channels/${channel._id}`}
-        className="w-full py-[6px] pl-[40px]"
+        className="flex w-full justify-between items-center py-[6px] pl-[40px] pr-[15px]"
       >
         <ChannelName
           isPrivate={channel.isPrivate}
           name={channel.name}
           className="flex items-center gap-[5px] select-none w-full"
         />
+        {channel.lastRead && (
+          <span className="py-1 px-2 rounded-2xl bg-primary text-offWhite text-s12 tracking-tighter font-bold">
+            new
+          </span>
+        )}
       </Link>
     </li>
   );

--- a/client/src/layouts/CommunityNav/index.tsx
+++ b/client/src/layouts/CommunityNav/index.tsx
@@ -12,6 +12,7 @@ import cn from 'classnames';
 import React, { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 
+// TODO: 이름은 `CommunityNav`인데 내용은 채널들의 네비게이션이라 `ChannelNav`로 바꿔도 좋을듯
 const CommunityNav = () => {
   const params = useParams() as { communityId: string; roomId?: string };
   const { communityId, roomId } = params;
@@ -33,13 +34,13 @@ const CommunityNav = () => {
 
   const handleRightClickChannelItem =
     (channel: JoinedChannel): MouseEventHandler<HTMLLIElement> =>
-    (e) => {
-      openContextMenuModal({
-        x: e.clientX,
-        y: e.clientY,
-        content: <ChannelContextMenu channel={channel} />,
-      });
-    };
+      (e) => {
+        openContextMenuModal({
+          x: e.clientX,
+          y: e.clientY,
+          content: <ChannelContextMenu channel={channel} />,
+        });
+      };
 
   const handleClickChannelCreateButton = () => {
     openCommonModal({

--- a/client/src/layouts/Gnb/index.tsx
+++ b/client/src/layouts/Gnb/index.tsx
@@ -2,6 +2,7 @@ import type { CommunitySummary } from '@apis/community';
 import type { MouseEventHandler } from 'react';
 
 import Avatar from '@components/Avatar';
+import Badge from '@components/Badge';
 import CommunityContextMenu from '@components/CommunityContextMenu';
 import CommunityCreateBox from '@components/CommunityCreateBox';
 import ErrorIcon from '@components/ErrorIcon';
@@ -103,12 +104,29 @@ const Gnb = () => {
                         to={`/communities/${_id}`}
                         onContextMenu={handleRightClickCommunityLink(community)}
                       >
-                        <Avatar
-                          name={name}
-                          size="small"
-                          variant="rectangle"
-                          url={profileUrl}
-                        />
+                        {community.channels.some(
+                          (channel) => channel.lastRead,
+                        ) ? (
+                          <Badge
+                            vertical="top"
+                            horizontal="left"
+                            color="primary"
+                          >
+                            <Avatar
+                              name={name}
+                              size="small"
+                              variant="rectangle"
+                              url={profileUrl}
+                            />
+                          </Badge>
+                        ) : (
+                          <Avatar
+                            name={name}
+                            size="small"
+                            variant="rectangle"
+                            url={profileUrl}
+                          />
+                        )}
                       </Link>
                     </GnbItemContainer>
                   </li>

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -8,7 +8,10 @@ import ChannelUserStatus from '@layouts/ChannelUserStatus';
 import React, { useRef, useEffect, Fragment } from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
 import { useParams } from 'react-router-dom';
-
+// TODO: 채널 페이지 입장시 setQueryData로 lastRead false로 날리기
+// 현재 문제: gnb에서 커뮤니티는 자기 채널 목록 중 하나라도 lastread가 true면 뱃지 띄워줘서
+// 이 데이터를 setQueryData로 고치면 채널 다 lastread false 되었을 때 뱃지도 사라지겠네
+// 라고 생각했는데 채널 페이지에서 가져오는 채널 데이터는 다른 엔드포인트 뚫어서 사용하고 있음
 const Channel = () => {
   const scrollbarContainerRef = useRef<Scrollbars>(null);
 


### PR DESCRIPTION
## Issues
- #261
- #262 

## 🤷‍♂️ Description

안 읽은 메시지 있으면 gnb 아이템과 채널 아이템에 표시


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 안 읽은 메시지 gnb 아이템에 뱃지 표시
- [X] 안 읽은 메시지 채널 아이템에 플래그 표시


## 📷 Screenshots

![image](https://user-images.githubusercontent.com/57662010/206056460-8805c1c0-cf27-4433-8119-d3f1d77b7f0f.png)

 
## 📒 Remarks
DM 안 읽읽음은 생각하지 않았음
