### PR TITLE
[CLIENT] 커뮤니티 아이디, 채널 아이디 path params 검증

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,3 +1,4 @@
+import CommunityLayer from '@layouts/CommunityLayer';
 import AccessDenied from '@pages/AccessDenied';
 import AuthorizedLayer from '@pages/AuthorizedLayer';
 import Channel from '@pages/Channel';
@@ -44,15 +45,8 @@ const router = createBrowserRouter(
           </Route>
           {/* TODO: communities/ 로 이동했을 때 리다이렉트할 url 정하기 */}
           <Route path="communities">
-            <Route
-              path=":communityId"
-              element={
-                <>
-                  <Outlet />
-                  {/* TODO: communityId가 올바른지 검증하기 */}
-                </>
-              }
-            >
+            <Route index element={<Navigate to="/dms" replace />} />
+            <Route path=":communityId" element={<CommunityLayer />}>
               <Route index element={<Community />} />
               <Route path="channels">
                 <Route index element={<Navigate to="/dms" replace />} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,3 +1,4 @@
+import ChannelLayer from '@layouts/ChannelLayer';
 import CommunityLayer from '@layouts/CommunityLayer';
 import AccessDenied from '@pages/AccessDenied';
 import AuthorizedLayer from '@pages/AuthorizedLayer';
@@ -43,22 +44,13 @@ const router = createBrowserRouter(
               <Route index element={<DMRoom />} />
             </Route>
           </Route>
-          {/* TODO: communities/ 로 이동했을 때 리다이렉트할 url 정하기 */}
           <Route path="communities">
             <Route index element={<Navigate to="/dms" replace />} />
             <Route path=":communityId" element={<CommunityLayer />}>
               <Route index element={<Community />} />
               <Route path="channels">
                 <Route index element={<Navigate to="/dms" replace />} />
-                <Route
-                  path=":roomId"
-                  element={
-                    <>
-                      <Outlet />
-                      {/* TODO: roomId가 올바른지 검증하기 */}
-                    </>
-                  }
-                >
+                <Route path=":roomId" element={<ChannelLayer />}>
                   <Route index element={<Channel />} />
                 </Route>
               </Route>

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -6,6 +6,7 @@ import type {
   LeaveCommunityResult,
   InviteCommunityResult,
   CommunitySummaries,
+  CommunitySummary,
 } from '@apis/community';
 import type { UseMutationOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
@@ -20,6 +21,27 @@ import {
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import queryKeyCreator from 'src/queryKeyCreator';
+
+export type CommunitiesMap = Record<CommunitySummary['_id'], CommunitySummary>;
+/**
+ *
+ * @returns 쿼리 클라이언트에 캐싱된 커뮤니티 목록을 `Record<CommunitySummary['_id'], CommunitySummary>` 형태로 반환한다.
+ */
+export const useCommunitiesMapQueryData = (): CommunitiesMap | undefined => {
+  const queryClient = useQueryClient();
+
+  const key = queryKeyCreator.community.all();
+  const communitiesQueryData =
+    queryClient.getQueryData<CommunitySummaries>(key);
+
+  return communitiesQueryData?.reduce(
+    (acc, community) => ({
+      ...acc,
+      [community._id]: community,
+    }),
+    {},
+  );
+};
 
 export const useCommunitiesQuery = () => {
   const queryClient = useQueryClient();

--- a/client/src/layouts/ChannelLayer/index.tsx
+++ b/client/src/layouts/ChannelLayer/index.tsx
@@ -1,0 +1,27 @@
+import { useCommunitiesMapQueryData } from '@hooks/community';
+import React from 'react';
+import { Navigate, Outlet, useParams } from 'react-router-dom';
+
+/**
+ * 채널 아이디가 올바른지 확인하는 레이어
+ * 사용자가 해당 채널에 속해있다면 올바르다.
+ * 올바르지 않다면 `/dms` 페이지로 리다이렉트한다.
+ */
+
+const ChannelLayer = () => {
+  const params = useParams();
+  const communityId = params.communityId as string;
+  const roomId = params.roomId as string;
+  const communitiesMapQueryData = useCommunitiesMapQueryData();
+
+  if (
+    !communitiesMapQueryData?.[communityId].channels.find(
+      (channel) => channel._id === roomId,
+    )
+  )
+    return <Navigate to="/dms" replace />;
+
+  return <Outlet />;
+};
+
+export default ChannelLayer;

--- a/client/src/layouts/CommunityLayer/index.tsx
+++ b/client/src/layouts/CommunityLayer/index.tsx
@@ -1,0 +1,21 @@
+import { useCommunitiesMapQueryData } from '@hooks/community';
+import React from 'react';
+import { Navigate, Outlet, useParams } from 'react-router-dom';
+
+/**
+ * 커뮤니티 아이디가 올바른지 확인하는 레이어
+ * 사용자가 해당 커뮤니티에 속해있다면 올바르다.
+ * 올바르지 않다면 `/dms` 페이지로 리다이렉트한다.
+ */
+const CommunityLayer = () => {
+  const params = useParams();
+  const communityId = params.communityId as string;
+  const communitiesMapQueryData = useCommunitiesMapQueryData();
+
+  if (!communitiesMapQueryData?.[communityId])
+    return <Navigate to="/dms" replace />;
+
+  return <Outlet />;
+};
+
+export default CommunityLayer;


### PR DESCRIPTION
## Issues
- #257 

## 🤷‍♂️ Description

path param의 커뮤니티 아이디와 채널 아이디가 올바르지 않으면 `/dms`로 리다이렉트한다.


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `/communities/:communityId`에서 아이디 올바르지 않으면 `/dms`로 리다이렉트
- [X] `/communities/:communityid/channels/:channelId`에서 채널 아이디 올바르지 않으면 `/dms`로 리다이렉트


## 📷 Screenshots

![Animation](https://user-images.githubusercontent.com/57662010/206057462-3b017748-ade2-408c-8705-2b1c116974a1.gif)

 
## 📒 Remarks

캐싱을 고려하여 getQueryData로 가져올건지 useQuery로 가져올 건지 Map으로 가져올 건지 배열로 가져올 건지 일관된 리팩토링 필요함