### PR TITLE
[Server/chat] api url 및 채팅 저장 dto 변경

### DIFF
--- a/server/apps/api/src/chat-list/chat-list.controller.ts
+++ b/server/apps/api/src/chat-list/chat-list.controller.ts
@@ -4,21 +4,27 @@ import { JwtAccessGuard } from '@auth/guard';
 import { RestoreMessageDto } from '@chat-list/dto';
 import { responseForm } from '@utils/responseForm';
 
-@Controller('api/chat')
+@Controller('api/channels')
 export class ChatListController {
   constructor(private chatListService: ChatListService) {}
 
-  @Post(':channel_id')
+  @Post(':channel_id/message')
   @UseGuards(JwtAccessGuard)
   async restoreMessage(
     @Param('channel_id') channel_id,
     @Body() restoreMessageDto: RestoreMessageDto,
+    @Req() req: any,
   ) {
-    await this.chatListService.restoreMessage({ ...restoreMessageDto, channel_id });
+    const requestUserId = req.user_id;
+    await this.chatListService.restoreMessage({
+      ...restoreMessageDto,
+      channel_id,
+      senderId: requestUserId,
+    });
     return responseForm(200, { message: '채팅 저장 성공!' });
   }
 
-  @Get(':channel_id')
+  @Get(':channel_id/message')
   @UseGuards(JwtAccessGuard)
   async getMessage(@Param('channel_id') channel_id, @Query() query: any, @Req() req: any) {
     const requestUserId = req.user._id;

--- a/server/apps/api/src/chat-list/dto/restore-message.dto.ts
+++ b/server/apps/api/src/chat-list/dto/restore-message.dto.ts
@@ -16,6 +16,6 @@ export class RestoreMessageDto {
   content: string;
 
   @IsString()
-  @IsNotEmpty()
+  @IsOptional()
   senderId: string;
 }


### PR DESCRIPTION
## 🤷‍♂️ Description

- 채팅에 관련한 API url 변경
  - 채팅 저장 : `POST /api/chat/:channel_id` -> `POST /api/channels/:channel_id/message`
  - 채팅 받아오기 : `GET /api/chat/:channel_id` -> `GET /api/channels/:channel_id/message`
  - 안 읽은 채팅 위치 : `GET /api/chat/:channel_id/unread-message` -> `GET /api/channels/:channel_id/unread-message`

- 채팅 저장 dto 변경 (senderId를 accessToken을 확인해서 받아옴)
  - 수정 전 : type, content, senderId
  - 수정 후 : type, content