### PR TITLE
[Server/chat] 채팅 저장 시 accessToken에서 유저 정보 받아오지 않는 오류 해결

### DIFF
--- a/server/apps/api/src/chat-list/chat-list.controller.ts
+++ b/server/apps/api/src/chat-list/chat-list.controller.ts
@@ -15,7 +15,7 @@ export class ChatListController {
     @Body() restoreMessageDto: RestoreMessageDto,
     @Req() req: any,
   ) {
-    const requestUserId = req.user_id;
+    const requestUserId = req.user._id;
     await this.chatListService.restoreMessage({
       ...restoreMessageDto,
       channel_id,


### PR DESCRIPTION
## 🤷‍♂️ Description

오타로 인한 오류였습니다..😓
`req.user_id` -> `req.user._id`
