### PR TITLE
[CLIENT] `Channel` 페이지에서 채팅 목록을 페이지 단위로 렌더링하는 `ChatList` 컴포넌트 분리

### DIFF
--- a/client/src/components/ChatList/index.tsx
+++ b/client/src/components/ChatList/index.tsx
@@ -1,0 +1,28 @@
+import type { Chat } from '@apis/chat';
+import type { User } from '@apis/user';
+import type { ComponentPropsWithoutRef, FC } from 'react';
+
+import ChatItem from '@components/ChatItem';
+import React from 'react';
+
+interface Props extends ComponentPropsWithoutRef<'ul'> {
+  chats: Chat[];
+  users: User[];
+}
+
+const ChatList: FC<Props> = ({ chats, users }) => {
+  return (
+    <ul>
+      {chats.map((chat) => (
+        <ChatItem
+          key={chat.id}
+          chat={chat}
+          className="px-5 py-3 tracking-tighter"
+          user={users.find((user) => user._id === chat.senderId)}
+        />
+      ))}
+    </ul>
+  );
+};
+
+export default ChatList;

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -2,7 +2,7 @@ import type { User } from '@apis/user';
 
 import ChannelMetadata from '@components/ChannelMetadata';
 import ChatForm from '@components/ChatForm';
-import ChatItem from '@components/ChatItem';
+import ChatList from '@components/ChatList';
 import Spinner from '@components/Spinner';
 import { useChannelQuery } from '@hooks/channel';
 import { useChatsInfiniteQuery, useSetChatsQuery } from '@hooks/chat';
@@ -123,18 +123,12 @@ const Channel = () => {
                 channelQuery.data &&
                 chatsInfiniteQuery.data.pages.map((page) =>
                   page.chat?.length ? (
-                    <Fragment key={page.chat[0].id}>
-                      {page.chat.map((chat) => (
-                        <ChatItem
-                          key={chat.id}
-                          chat={chat}
-                          className="px-5 py-3 tracking-tighter"
-                          user={channelQuery.data.users.find(
-                            (user) => user._id === chat.senderId,
-                          )}
-                        />
-                      ))}
-                    </Fragment>
+                    <li key={page.chat[0].id}>
+                      <ChatList
+                        users={channelQuery.data.users}
+                        chats={page.chat}
+                      />
+                    </li>
                   ) : (
                     <Fragment key={channelQuery.data._id}>
                       {channelQuery.data && channelQuery.data.users && (


### PR DESCRIPTION
# ⚠️ Record<아이디, 객체> 적용하는 리팩토링 후 그에 맞추어 다시 props 전달할 예정임
## Issues
- #271

## 🤷‍♂️ Description

`Channel` 페이지에서 채팅 목록을 페이지 단위로 렌더링하는 `ChatList` 컴포넌트 분리