### PR TITLE
[CLIENT] `select` 옵션에서 `Record<id, 데이터>` 형태로 내보내어 탐색 개선

### DIFF
--- a/client/src/components/ChatList/index.tsx
+++ b/client/src/components/ChatList/index.tsx
@@ -1,0 +1,35 @@
+import type { GetChatsResult } from '@apis/chat';
+import type { UsersMap } from '@hooks/user';
+import type { FC } from 'react';
+
+import ChatItem from '@components/ChatItem';
+import React, { Fragment } from 'react';
+
+interface Props {
+  pages: GetChatsResult[];
+  users: UsersMap;
+}
+
+const ChatList: FC<Props> = ({ pages, users }) => {
+  return (
+    <>
+      {pages.map(
+        (page) =>
+          page.chat?.length && (
+            <Fragment key={page.chat[0].id}>
+              {page.chat.map((chat) => (
+                <ChatItem
+                  key={chat.id}
+                  chat={chat}
+                  className="px-5 py-3 tracking-tighter"
+                  user={users[chat.senderId]}
+                />
+              ))}
+            </Fragment>
+          ),
+      )}
+    </>
+  );
+};
+
+export default ChatList;

--- a/client/src/components/ChatList/index.tsx
+++ b/client/src/components/ChatList/index.tsx
@@ -13,20 +13,21 @@ interface Props {
 const ChatList: FC<Props> = ({ pages, users }) => {
   return (
     <>
-      {pages.map(
-        (page) =>
-          page.chat?.length && (
-            <Fragment key={page.chat[0].id}>
-              {page.chat.map((chat) => (
-                <ChatItem
-                  key={chat.id}
-                  chat={chat}
-                  className="px-5 py-3 tracking-tighter"
-                  user={users[chat.senderId]}
-                />
-              ))}
-            </Fragment>
-          ),
+      {pages.map((page) =>
+        page.chat?.length ? (
+          <Fragment key={page.chat[0].id}>
+            {page.chat.map((chat) => (
+              <ChatItem
+                key={chat.id}
+                chat={chat}
+                className="px-5 py-3 tracking-tighter"
+                user={users[chat.senderId]}
+              />
+            ))}
+          </Fragment>
+        ) : (
+          <></>
+        ),
       )}
     </>
   );

--- a/client/src/components/CommunityInviteUserSearchResult/index.tsx
+++ b/client/src/components/CommunityInviteUserSearchResult/index.tsx
@@ -6,7 +6,7 @@ import defaultErrorHandler from '@errors/defaultErrorHandler';
 import { UserPlusIcon } from '@heroicons/react/20/solid';
 import { useInviteCommunityMutation } from '@hooks/community';
 import {
-  useCommunityUsersQuery,
+  useCommunityUsersMapQuery,
   useInvalidateCommunityUsersQuery,
 } from '@hooks/user';
 import React from 'react';
@@ -19,7 +19,7 @@ interface Props {
 }
 
 const CommunityInviteUserSearchResult: FC<Props> = ({ users, communityId }) => {
-  const { communityUsersQuery } = useCommunityUsersQuery(communityId);
+  const communityUsersMap = useCommunityUsersMapQuery(communityId);
   const inviteCommunityMutation = useInviteCommunityMutation();
   const { invalidateCommunityUsersQuery } =
     useInvalidateCommunityUsersQuery(communityId);
@@ -55,9 +55,7 @@ const CommunityInviteUserSearchResult: FC<Props> = ({ users, communityId }) => {
       <ul>
         {users.map((user) => {
           /** 이미 커뮤니티에 포함된 사용자라면, true */
-          const disabled = communityUsersQuery.data?.some(
-            ({ _id }) => _id === user._id,
-          );
+          const disabled = !!communityUsersMap.data?.[user._id];
 
           return (
             <UserItem

--- a/client/src/components/FollowerUserSearchResult/index.tsx
+++ b/client/src/components/FollowerUserSearchResult/index.tsx
@@ -54,7 +54,7 @@ const FollowerUserSearchResult: FC<Props> = ({ users }) => {
               key={user._id}
               user={user}
               left={
-                isFollowing && <div className="text-placeholder">팔로잉</div>
+                isFollowing && <div className="text-placeholder">맞팔로우</div>
               }
               right={
                 isFollowing ? (

--- a/client/src/components/FollowerUserSearchResult/index.tsx
+++ b/client/src/components/FollowerUserSearchResult/index.tsx
@@ -5,7 +5,7 @@ import FollowerUserContextMenu from '@components/FollowerUserContextMenu';
 import UserItem from '@components/UserItem';
 import UserList from '@components/UserList';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
-import useFollowingsQuery from '@hooks/useFollowingsQuery';
+import { useFollowingsMapQuery } from '@hooks/useFollowingsQuery';
 import { useRootStore } from '@stores/rootStore';
 import React from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
@@ -23,7 +23,7 @@ const FollowerUserSearchResult: FC<Props> = ({ users }) => {
     (state) => state.openContextMenuModal,
   );
 
-  const followingsQuery = useFollowingsQuery();
+  const followingsMapQuery = useFollowingsMapQuery();
 
   const handleMoreButtonClick: (
     user: User,
@@ -47,9 +47,7 @@ const FollowerUserSearchResult: FC<Props> = ({ users }) => {
     <Scrollbars>
       <UserList>
         {users.map((user) => {
-          const isFollowing = !!followingsQuery.data?.find(
-            (f) => f._id === user._id,
-          );
+          const isFollowing = !!followingsMapQuery.data?.[user._id];
 
           return (
             <UserItem

--- a/client/src/components/FollowingUserSearchResult/index.tsx
+++ b/client/src/components/FollowingUserSearchResult/index.tsx
@@ -54,7 +54,7 @@ const FollowingUserSearchResult: FC<Props> = ({ users }) => {
               key={user._id}
               user={user}
               left={
-                isFollowers && <div className="text-placeholder">팔로워</div>
+                isFollowers && <div className="text-placeholder">맞팔로우</div>
               }
               right={
                 <div className="flex gap-4">

--- a/client/src/components/FollowingUserSearchResult/index.tsx
+++ b/client/src/components/FollowingUserSearchResult/index.tsx
@@ -5,7 +5,7 @@ import FollowingUserContextMenu from '@components/FollowingUserContextMenu';
 import UserItem from '@components/UserItem';
 import UserList from '@components/UserList';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
-import useFollowersQuery from '@hooks/useFollowersQuery';
+import { useFollowersMapQuery } from '@hooks/useFollowersQuery';
 import { useRootStore } from '@stores/rootStore';
 import React from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
@@ -23,7 +23,7 @@ const FollowingUserSearchResult: FC<Props> = ({ users }) => {
     (state) => state.openContextMenuModal,
   );
 
-  const followersQuery = useFollowersQuery();
+  const followersMapQuery = useFollowersMapQuery();
 
   const handleMoreButtonClick: (
     user: User,
@@ -47,9 +47,7 @@ const FollowingUserSearchResult: FC<Props> = ({ users }) => {
     <Scrollbars>
       <UserList>
         {users.map((user) => {
-          const isFollowers = !!followersQuery.data?.find(
-            (f) => f._id === user._id,
-          );
+          const isFollowers = !!followersMapQuery.data?.[user._id];
 
           return (
             <UserItem

--- a/client/src/components/UserSearchResult/index.tsx
+++ b/client/src/components/UserSearchResult/index.tsx
@@ -5,7 +5,7 @@ import FollowerUserContextMenu from '@components/FollowerUserContextMenu';
 import UserItem from '@components/UserItem';
 import UserList from '@components/UserList';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
-import useFollowersQuery from '@hooks/useFollowersQuery';
+import { useFollowersMapQuery } from '@hooks/useFollowersQuery';
 import useFollowingsQuery from '@hooks/useFollowingsQuery';
 import { useRootStore } from '@stores/rootStore';
 import React from 'react';
@@ -22,7 +22,7 @@ interface Props {
 const UserSearchResult: FC<Props> = ({ users }) => {
   const openCommonModal = useRootStore((state) => state.openCommonModal);
 
-  const followersQuery = useFollowersQuery();
+  const followersMapQuery = useFollowersMapQuery();
   const followingsQuery = useFollowingsQuery();
 
   const handleMoreButtonClick: (
@@ -51,9 +51,7 @@ const UserSearchResult: FC<Props> = ({ users }) => {
           const isFollowing = !!followingsQuery.data?.find(
             (f) => f._id === user._id,
           );
-          const isFollower = !!followersQuery.data?.find(
-            (f) => f._id === user._id,
-          );
+          const isFollower = !!followersMapQuery.data?.[user._id];
 
           return (
             <UserItem

--- a/client/src/components/UserSearchResult/index.tsx
+++ b/client/src/components/UserSearchResult/index.tsx
@@ -57,9 +57,15 @@ const UserSearchResult: FC<Props> = ({ users }) => {
               user={user}
               left={
                 <div className="flex gap-2 text-placeholder">
-                  {isFollowing && <div>팔로잉</div>}
-                  {isFollowing && isFollower && '•'}
-                  {isFollower && <div>팔로워</div>}
+                  {isFollowing && isFollower ? (
+                    <div>맞팔로우</div>
+                  ) : isFollowing ? (
+                    <div>팔로잉</div>
+                  ) : isFollower ? (
+                    <div>팔로워</div>
+                  ) : (
+                    <></>
+                  )}
                 </div>
               }
               right={

--- a/client/src/components/UserSearchResult/index.tsx
+++ b/client/src/components/UserSearchResult/index.tsx
@@ -6,7 +6,7 @@ import UserItem from '@components/UserItem';
 import UserList from '@components/UserList';
 import { EllipsisHorizontalIcon } from '@heroicons/react/20/solid';
 import { useFollowersMapQuery } from '@hooks/useFollowersQuery';
-import useFollowingsQuery from '@hooks/useFollowingsQuery';
+import { useFollowingsMapQuery } from '@hooks/useFollowingsQuery';
 import { useRootStore } from '@stores/rootStore';
 import React from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
@@ -23,7 +23,7 @@ const UserSearchResult: FC<Props> = ({ users }) => {
   const openCommonModal = useRootStore((state) => state.openCommonModal);
 
   const followersMapQuery = useFollowersMapQuery();
-  const followingsQuery = useFollowingsQuery();
+  const followingsMapQuery = useFollowingsMapQuery();
 
   const handleMoreButtonClick: (
     user: User,
@@ -48,9 +48,7 @@ const UserSearchResult: FC<Props> = ({ users }) => {
     <Scrollbars>
       <UserList>
         {users.map((user) => {
-          const isFollowing = !!followingsQuery.data?.find(
-            (f) => f._id === user._id,
-          );
+          const isFollowing = !!followingsMapQuery.data?.[user._id];
           const isFollower = !!followersMapQuery.data?.[user._id];
 
           return (

--- a/client/src/hooks/channel.ts
+++ b/client/src/hooks/channel.ts
@@ -1,4 +1,5 @@
 import type {
+  Channel,
   CreateChannelRequest,
   CreateChannelResult,
   GetChannelResult,
@@ -6,6 +7,7 @@ import type {
   LeaveChannelResult,
 } from '@apis/channel';
 import type { CommunitySummaries } from '@apis/community';
+import type { UsersMap } from '@hooks/user';
 import type {
   MutationOptions,
   UseMutationOptions,
@@ -31,6 +33,35 @@ export const useChannelQuery = (channelId: string) => {
   );
 
   return { channelQuery: query, invalidateChannelQuery: invalidate };
+};
+
+// TODO: 적절한 이름 짓기
+export type UsersNormalizedChannel = Omit<Channel, 'users'> & {
+  users: UsersMap;
+};
+
+/**
+ *
+ * @param channelId 채널 id
+ * @returns `users`가 `UsersMap`인 `Channel` 객체
+ */
+export const useUsersNormalizedChannelQuery = (channelId: string) => {
+  const key = queryKeyCreator.channel.detail(channelId);
+  const query = useQuery<GetChannelResult, AxiosError, UsersNormalizedChannel>(
+    key,
+    () => getChannel(channelId),
+    {
+      select: (channel) => ({
+        ...channel,
+        users: channel.users.reduce(
+          (acc, cur) => ({ ...acc, [cur._id]: cur }),
+          {},
+        ),
+      }),
+    },
+  );
+
+  return query;
 };
 
 export const useCreateChannelMutation = (

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -43,6 +43,20 @@ export const useCommunitiesMapQueryData = (): CommunitiesMap | undefined => {
   );
 };
 
+export const useCommunitiesMapQuery = () => {
+  const key = queryKeyCreator.community.all();
+  const query = useQuery<CommunitySummaries, AxiosError, CommunitiesMap>(
+    key,
+    getCommunities,
+    {
+      select: (communities) =>
+        communities.reduce((acc, cur) => ({ ...acc, [cur._id]: cur }), {}),
+    },
+  );
+
+  return query;
+};
+
 export const useCommunitiesQuery = () => {
   const queryClient = useQueryClient();
 

--- a/client/src/hooks/useFollowersQuery.ts
+++ b/client/src/hooks/useFollowersQuery.ts
@@ -25,3 +25,14 @@ const useFollowersQuery = (
 };
 
 export default useFollowersQuery;
+
+export type FollowersMap = Record<User['id'], User>;
+export const useFollowersMapQuery = () => {
+  const key = queryKeyCreator.followers();
+  const query = useQuery<User[], AxiosError, FollowersMap>(key, getFollowers, {
+    select: (followers) =>
+      followers.reduce((acc, cur) => ({ ...acc, [cur._id]: cur }), {}),
+  });
+
+  return query;
+};

--- a/client/src/hooks/useFollowingsQuery.ts
+++ b/client/src/hooks/useFollowingsQuery.ts
@@ -27,6 +27,21 @@ const useFollowingsQuery = (
 
 export default useFollowingsQuery;
 
+export type FollowingsMap = Record<User['id'], User>;
+export const useFollowingsMapQuery = () => {
+  const key = queryKeyCreator.followings.all();
+  const query = useQuery<User[], AxiosError, FollowingsMap>(
+    key,
+    getFollowings,
+    {
+      select: (followings) =>
+        followings.reduce((acc, cur) => ({ ...acc, [cur._id]: cur }), {}),
+    },
+  );
+
+  return query;
+};
+
 export const useInvalidateFollowingsQuery = () => {
   const key = queryKeyCreator.followings.all();
 

--- a/client/src/hooks/user.ts
+++ b/client/src/hooks/user.ts
@@ -51,3 +51,19 @@ export const useChannelUsersMapQuery = (channelId: string) => {
 
   return { channelUsersMapQuery: query };
 };
+
+export type CommunityUsersMap = Record<UserUID, User>;
+export const useCommunityUsersMapQuery = (communityId: string) => {
+  const key = queryKeyCreator.user.communityUsers(communityId);
+
+  const query = useQuery<User[], AxiosError, CommunityUsersMap>(
+    key,
+    () => getCommunityUsers(communityId),
+    {
+      select: (users) =>
+        users.reduce((acc, cur) => ({ ...acc, [cur._id]: cur }), {}),
+    },
+  );
+
+  return query;
+};

--- a/client/src/layouts/CommunityNav/index.tsx
+++ b/client/src/layouts/CommunityNav/index.tsx
@@ -6,7 +6,10 @@ import ChannelCreateBox from '@components/ChannelCreateBox';
 import ChannelItem from '@components/ChannelItem';
 import ErrorMessage from '@components/ErrorMessage';
 import { ChevronDownIcon, PlusIcon } from '@heroicons/react/20/solid';
-import { useCommunitiesQuery, useJoinedChannelsQuery } from '@hooks/community';
+import {
+  useCommunitiesMapQuery,
+  useJoinedChannelsQuery,
+} from '@hooks/community';
 import { useRootStore } from '@stores/rootStore';
 import cn from 'classnames';
 import React, { useState } from 'react';
@@ -15,10 +18,8 @@ import { useParams, Link } from 'react-router-dom';
 const CommunityNav = () => {
   const params = useParams() as { communityId: string; roomId?: string };
   const { communityId, roomId } = params;
-  const { communitiesQuery } = useCommunitiesQuery();
-  const communitySummary = communitiesQuery.data?.find(
-    ({ _id }) => _id === communityId,
-  );
+  const communitiesMapQuery = useCommunitiesMapQuery();
+  const communitySummary = communitiesMapQuery.data?.[communityId];
   const { joinedChannelsQuery } = useJoinedChannelsQuery(communityId);
   const joinedChannelsLength = joinedChannelsQuery.data?.length || 0;
 

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -1,7 +1,7 @@
 import type { User } from '@apis/user';
 
 import ChatForm from '@components/ChatForm';
-import ChatItem from '@components/ChatItem';
+import ChatList from '@components/ChatList';
 import Spinner from '@components/Spinner';
 import { faker } from '@faker-js/faker';
 import { useUsersNormalizedChannelQuery } from '@hooks/channel';
@@ -12,7 +12,7 @@ import ChannelUserStatus from '@layouts/ChannelUserStatus';
 import { useRootStore } from '@stores/rootStore';
 import { useSocketStore } from '@stores/socketStore';
 import { isScrollTouchedBottom } from '@utils/scrollValues';
-import React, { useRef, Fragment, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import Scrollbars from 'react-custom-scrollbars-2';
 import { useParams } from 'react-router-dom';
 
@@ -121,25 +121,12 @@ const Channel = () => {
           >
             <div ref={intersectionObservable} />
             <ul className="flex flex-col gap-3 [&>*:hover]:bg-background">
-              {chatsInfiniteQuery.data &&
-                normalizedChannelQuery.data &&
-                chatsInfiniteQuery.data.pages.map(
-                  (page) =>
-                    page.chat?.length && (
-                      <Fragment key={page.chat[0].id}>
-                        {page.chat.map((chat) => (
-                          <ChatItem
-                            key={chat.id}
-                            chat={chat}
-                            className="px-5 py-3 tracking-tighter"
-                            user={
-                              normalizedChannelQuery.data.users[chat.senderId]
-                            }
-                          />
-                        ))}
-                      </Fragment>
-                    ),
-                )}
+              {chatsInfiniteQuery.data && normalizedChannelQuery.data && (
+                <ChatList
+                  pages={chatsInfiniteQuery.data.pages}
+                  users={normalizedChannelQuery.data.users}
+                />
+              )}
             </ul>
           </Scrollbars>
           <ChatForm

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -1,6 +1,5 @@
 import type { User } from '@apis/user';
 
-import ChannelMetadata from '@components/ChannelMetadata';
 import ChatForm from '@components/ChatForm';
 import ChatItem from '@components/ChatItem';
 import Spinner from '@components/Spinner';
@@ -122,37 +121,22 @@ const Channel = () => {
             <ul className="flex flex-col gap-3 [&>*:hover]:bg-background">
               {chatsInfiniteQuery.data &&
                 channelQuery.data &&
-                chatsInfiniteQuery.data.pages.map((page) =>
-                  page.chat?.length ? (
-                    <Fragment key={page.chat[0].id}>
-                      {page.chat.map((chat) => (
-                        <ChatItem
-                          key={chat.id}
-                          chat={chat}
-                          className="px-5 py-3 tracking-tighter"
-                          user={channelQuery.data.users.find(
-                            (user) => user._id === chat.senderId,
-                          )}
-                        />
-                      ))}
-                    </Fragment>
-                  ) : (
-                    <Fragment key={channelQuery.data._id}>
-                      {channelQuery.data && channelQuery.data.users && (
-                        <div className="p-8">
-                          <ChannelMetadata
-                            channel={channelQuery.data}
-                            managerName={
-                              channelQuery.data.users.find(
-                                (user) =>
-                                  user._id === channelQuery.data.managerId,
-                              )?.nickname
-                            }
+                chatsInfiniteQuery.data.pages.map(
+                  (page) =>
+                    page.chat?.length && (
+                      <Fragment key={page.chat[0].id}>
+                        {page.chat.map((chat) => (
+                          <ChatItem
+                            key={chat.id}
+                            chat={chat}
+                            className="px-5 py-3 tracking-tighter"
+                            user={channelQuery.data.users.find(
+                              (user) => user._id === chat.senderId,
+                            )}
                           />
-                        </div>
-                      )}
-                    </Fragment>
-                  ),
+                        ))}
+                      </Fragment>
+                    ),
                 )}
             </ul>
           </Scrollbars>


### PR DESCRIPTION
## Issues
- #271
- #266 


## 🤷‍♂️ Description

<!-- 어떤 문제에 관한 PR인지 간략하게 적어주세요. -->


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `ChatList` 컴포넌트 분리
- [X] `N`개의 데이터 목록 `A`에 대해 `M`개의 데이터 목록 `B`을 가져와 비교하는 로직에서 `useBMap` 훅을 정의하여 사용해서 탐색 복잡도를 N*M에서 N으로 줄임