### PR TITLE
[CLIENT] 채팅 전송 에러 핸들링

### DIFF
--- a/client/src/apis/chat.ts
+++ b/client/src/apis/chat.ts
@@ -13,6 +13,10 @@ export interface Chat {
   updatedAt: string;
   createdAt: string;
   deletedAt?: string;
+  written?: boolean | -1;
+  // -1: Optimistic Updates 중
+  // true: DB 쓰기에 성공
+  // false: DB 쓰기에 실패
 }
 
 export type GetChatsResult = {

--- a/client/src/components/Avatar/index.tsx
+++ b/client/src/components/Avatar/index.tsx
@@ -28,16 +28,14 @@ const SCALE = {
 };
 
 const getFirstLetter = (str: string) => {
-  const firstLetter = str.at(0);
-
-  if (!firstLetter) {
+  if (!str?.length) {
     console.warn(
       `getFirstLetter의 인자로는 반드시 길이 1이상의 문자열이 들어와야 합니다.`,
     );
     return '';
   }
 
-  return firstLetter;
+  return str?.at(0);
 };
 
 const BADGE_POSITION = {

--- a/client/src/components/ChatContent/index.tsx
+++ b/client/src/components/ChatContent/index.tsx
@@ -1,0 +1,21 @@
+import type { FC } from 'react';
+
+import React from 'react';
+
+export interface Props {
+  content: string;
+}
+
+const ChatContent: FC<Props> = ({ content }) => {
+  const lines = content.split('\n');
+
+  return (
+    <>
+      {lines.map((line, idx) => (
+        <p key={idx}>{line.length ? line : <br />}</p>
+      ))}
+    </>
+  );
+};
+
+export default ChatContent;

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -3,6 +3,7 @@ import type { User } from '@apis/user';
 import type { ComponentPropsWithoutRef, FC } from 'react';
 
 import Avatar from '@components/Avatar';
+import ChatContent from '@components/ChatContent';
 import { dateStringToKRLocaleDateString } from '@utils/date';
 import React, { memo } from 'react';
 
@@ -22,48 +23,53 @@ const ChatItem: FC<Props> = ({
   },
   isSystem = false,
 }) => {
-  const { content, createdAt } = chat;
+  const { content, createdAt, updatedAt, deletedAt } = chat;
+
+  const isUpdated = updatedAt && updatedAt !== createdAt;
+  const isDeleted = !!deletedAt;
 
   return (
-    <li className={className}>
-      <div className="flex gap-3">
-        <div className="pt-1">
-          <Avatar
-            variant="rectangle"
-            size="sm"
-            profileUrl={user.profileUrl}
-            name={user.nickname}
-          />
-        </div>
-        <div>
-          <div className="flex gap-2 items-center text-s16">
-            <span
-              className={`font-bold ${
-                isSystem ? 'text-primary' : 'text-indigo'
-              }`}
-            >
-              {user.nickname}
-            </span>
-            <span className="text-placeholder">
-              {dateStringToKRLocaleDateString(createdAt, {
-                hour: 'numeric',
-                minute: 'numeric',
-              })}
-            </span>
-            {chat?.deletedAt?.length ? (
-              <span className="text-label">(삭제됨)</span>
-            ) : chat?.updatedAt.length ? (
-              chat.createdAt !== chat.updatedAt && (
-                <span className="text-label">(수정됨)</span>
-              )
+    chat && (
+      <li className={className}>
+        <div className="flex gap-3">
+          <div className="pt-1">
+            <Avatar
+              variant="rectangle"
+              size="sm"
+              profileUrl={user.profileUrl}
+              name={user.nickname}
+            />
+          </div>
+          <div>
+            <div className="flex gap-2 items-center text-s16">
+              <span
+                className={`font-bold ${
+                  isSystem ? 'text-primary' : 'text-indigo'
+                }`}
+              >
+                {user.nickname}
+              </span>
+              <span className="text-placeholder">
+                {dateStringToKRLocaleDateString(createdAt, {
+                  hour: 'numeric',
+                  minute: 'numeric',
+                })}
+              </span>
+              {isDeleted ? (
+                <span className="text-label">(삭제됨)</span>
+              ) : (
+                isUpdated && <span className="text-label">(수정됨)</span>
+              )}
+            </div>
+            {isDeleted ? (
+              <div>삭제된 메시지입니다</div>
             ) : (
-              ''
+              <ChatContent content={content} />
             )}
           </div>
-          <div>{chat?.deletedAt ? '삭제된 메시지입니다' : content}</div>
         </div>
-      </div>
-    </li>
+      </li>
+    )
   );
 };
 

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -4,9 +4,11 @@ import type { ComponentPropsWithoutRef, FC } from 'react';
 
 import Avatar from '@components/Avatar';
 import ChatContent from '@components/ChatContent';
+import { useSetChatsQuery } from '@hooks/chat';
 import { dateStringToKRLocaleDateString } from '@utils/date';
 import cn from 'classnames';
 import React, { memo, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 interface Props extends ComponentPropsWithoutRef<'li'> {
   className?: string;
@@ -24,8 +26,11 @@ const ChatItem: FC<Props> = ({
   },
   isSystem = false,
 }) => {
-  const { content, createdAt, updatedAt, deletedAt, written } = chat;
+  const params = useParams();
+  const roomId = params.roomId as string;
+  const { content, createdAt, updatedAt, deletedAt, written, id } = chat;
   const [isHover, setIsHover] = useState(false);
+  const { removeChatQueryData } = useSetChatsQuery();
 
   const isUpdated = updatedAt && updatedAt !== createdAt;
   const isDeleted = !!deletedAt;
@@ -37,6 +42,9 @@ const ChatItem: FC<Props> = ({
   const failedChatControlButtonsClassnames = `flex items-center px-3 rounded`;
   const handleMouseEnter = () => setIsHover(true);
   const handleMouseLeave = () => setIsHover(false);
+  const handleClickDiscardButton = () => {
+    removeChatQueryData({ channelId: roomId, id });
+  };
 
   return (
     chat && (
@@ -80,20 +88,13 @@ const ChatItem: FC<Props> = ({
               )}
               <div className="flex justify-end grow gap-2 text-s14">
                 {isFailedToSendChat && isHover && (
-                  <>
-                    <button
-                      type="button"
-                      className={`${failedChatControlButtonsClassnames} bg-secondary hover:bg-secondary-dark text-offWhite`}
-                    >
-                      재전송
-                    </button>
-                    <button
-                      type="button"
-                      className={`${failedChatControlButtonsClassnames} bg-error hover:bg-error-dark text-offWhite`}
-                    >
-                      지우기
-                    </button>
-                  </>
+                  <button
+                    type="button"
+                    className={`${failedChatControlButtonsClassnames} bg-error hover:bg-error-dark text-offWhite`}
+                    onClick={handleClickDiscardButton}
+                  >
+                    지우기
+                  </button>
                 )}
               </div>
             </div>

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -5,7 +5,8 @@ import type { ComponentPropsWithoutRef, FC } from 'react';
 import Avatar from '@components/Avatar';
 import ChatContent from '@components/ChatContent';
 import { dateStringToKRLocaleDateString } from '@utils/date';
-import React, { memo } from 'react';
+import cn from 'classnames';
+import React, { memo, useState } from 'react';
 
 interface Props extends ComponentPropsWithoutRef<'li'> {
   className?: string;
@@ -23,14 +24,27 @@ const ChatItem: FC<Props> = ({
   },
   isSystem = false,
 }) => {
-  const { content, createdAt, updatedAt, deletedAt } = chat;
+  const { content, createdAt, updatedAt, deletedAt, written } = chat;
+  const [isHover, setIsHover] = useState(false);
 
   const isUpdated = updatedAt && updatedAt !== createdAt;
   const isDeleted = !!deletedAt;
+  const isFailedToSendChat = written === false;
+  const contentClassnames = cn({
+    'opacity-40': written === -1 || isFailedToSendChat,
+  });
+
+  const failedChatControlButtonsClassnames = `flex items-center px-3 rounded`;
+  const handleMouseEnter = () => setIsHover(true);
+  const handleMouseLeave = () => setIsHover(false);
 
   return (
     chat && (
-      <li className={className}>
+      <li
+        className={className}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
         <div className="flex gap-3">
           <div className="pt-1">
             <Avatar
@@ -40,32 +54,56 @@ const ChatItem: FC<Props> = ({
               name={user.nickname}
             />
           </div>
-          <div>
-            <div className="flex gap-2 items-center text-s16">
+          <div className="grow">
+            <div className="flex gap-2 items-center text-s16 mb-2">
               <span
                 className={`font-bold ${
                   isSystem ? 'text-primary' : 'text-indigo'
-                }`}
+                } ${contentClassnames}`}
               >
                 {user.nickname}
               </span>
-              <span className="text-placeholder">
-                {dateStringToKRLocaleDateString(createdAt, {
-                  hour: 'numeric',
-                  minute: 'numeric',
-                })}
-              </span>
+              {isFailedToSendChat ? (
+                <span className="text-error font-bold">전송 실패</span>
+              ) : (
+                <span className="text-placeholder">
+                  {dateStringToKRLocaleDateString(createdAt, {
+                    hour: 'numeric',
+                    minute: 'numeric',
+                  })}
+                </span>
+              )}
               {isDeleted ? (
                 <span className="text-label">(삭제됨)</span>
               ) : (
                 isUpdated && <span className="text-label">(수정됨)</span>
               )}
+              <div className="flex justify-end grow gap-2 text-s14">
+                {isFailedToSendChat && isHover && (
+                  <>
+                    <button
+                      type="button"
+                      className={`${failedChatControlButtonsClassnames} bg-secondary hover:bg-secondary-dark text-offWhite`}
+                    >
+                      재전송
+                    </button>
+                    <button
+                      type="button"
+                      className={`${failedChatControlButtonsClassnames} bg-error hover:bg-error-dark text-offWhite`}
+                    >
+                      지우기
+                    </button>
+                  </>
+                )}
+              </div>
             </div>
-            {isDeleted ? (
-              <div>삭제된 메시지입니다</div>
-            ) : (
-              <ChatContent content={content} />
-            )}
+            <div className={`${contentClassnames}`}>
+              {isDeleted ? (
+                '삭제된 메시지입니다'
+              ) : (
+                <ChatContent content={content} />
+              )}
+            </div>
           </div>
         </div>
       </li>

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -49,12 +49,12 @@ type UpdateChatToWittenChat = ({
 type UpdateChatToFailedChat = UpdateChatToWittenChat;
 type RemoveChatQueryData = UpdateChatToWittenChat;
 
-/**
- * - addChatsQueryData: 쿼리의 가장 마지막 페이지에 새로운 채팅 데이터를 추가
- */
 export const useSetChatsQuery = () => {
   const queryClient = useQueryClient();
 
+  /**
+   * - 쿼리 데이터의 가장 마지막 페이지, 마지막 인덱스에 새로운 채팅 데이터를 추가한다.
+   */
   const addChatsQueryData: AddChatsQueryData = ({
     id,
     channelId,
@@ -84,8 +84,7 @@ export const useSetChatsQuery = () => {
   };
 
   /**
-   * Optimistic Updates한 채팅의 id와 채널 id를 받아서, 해당 채팅의 written 프로퍼티를 true로 변경시키고,
-   * 채팅 쿼리 데이터 배열의 맨 뒤로 보낸다.
+   * Optimistic Updates한 채팅의 id와 채널 id를 받아서, 해당 채팅의 written 프로퍼티를 true로 변경시킨다,
    */
   const updateChatToWrittenChat: UpdateChatToWittenChat = ({
     id,
@@ -101,13 +100,9 @@ export const useSetChatsQuery = () => {
 
         if (!chatList) return;
 
-        const targetIndex = chatList.findIndex((chat) => chat.id === id);
+        const targetChat = chatList.find((chat) => chat.id === id);
 
-        if (targetIndex !== -1) {
-          const [targetChat] = chatList.splice(targetIndex, 1);
-
-          chatList.push({ ...targetChat, written: true }); // 보낸 채팅이 DB에 저장되었음을 나타낸다.
-        }
+        if (targetChat) targetChat.written = true;
       });
     });
   };

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -38,7 +38,7 @@ type AddChatsQueryData = ({
   written?: boolean | -1;
 }) => void;
 
-type UpdateChatToWittenChat = ({
+type UpdateChatToWrittenChat = ({
   id,
   channelId,
 }: {
@@ -46,8 +46,8 @@ type UpdateChatToWittenChat = ({
   channelId: string;
 }) => void;
 
-type UpdateChatToFailedChat = UpdateChatToWittenChat;
-type RemoveChatQueryData = UpdateChatToWittenChat;
+type UpdateChatToFailedChat = UpdateChatToWrittenChat;
+type RemoveChatQueryData = UpdateChatToWrittenChat;
 
 export const useSetChatsQuery = () => {
   const queryClient = useQueryClient();
@@ -86,7 +86,7 @@ export const useSetChatsQuery = () => {
   /**
    * Optimistic Updates한 채팅의 id와 채널 id를 받아서, 해당 채팅의 written 프로퍼티를 true로 변경시킨다,
    */
-  const updateChatToWrittenChat: UpdateChatToWittenChat = ({
+  const updateChatToWrittenChat: UpdateChatToWrittenChat = ({
     id,
     channelId,
   }) => {

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -31,13 +31,14 @@ const SocketLayer = () => {
   const { addChatsQueryData } = useSetChatsQuery();
 
   useEffect(() => {
+    const opts = {
+      auth: { token: `Bearer ${accessToken}` },
+    };
+
     const newSockets = communityIds.reduce((acc, communityId) => {
       acc[communityId] =
         sockets[communityId] ??
-        io({
-          path: `${SOCKET_URL}/socket/commu-${communityId}`,
-          auth: { token: `Bearer ${accessToken}` },
-        });
+        io(`${SOCKET_URL}/socket/commu-${communityId}`, opts);
       return acc;
     }, {} as Sockets);
 

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -4,6 +4,7 @@ import type { Sockets } from '@stores/socketStore';
 
 import { SOCKET_URL } from '@constants/url';
 import { useSetChatsQuery } from '@hooks/chat';
+import { useMyInfo } from '@hooks/useMyInfoQuery';
 import { useRootStore } from '@stores/rootStore';
 import { useSocketStore } from '@stores/socketStore';
 import { useTokenStore } from '@stores/tokenStore';
@@ -15,6 +16,7 @@ import { io } from 'socket.io-client';
 import { joinChannelsPayload, SOCKET_EVENTS } from '@/socketEvents';
 
 const SocketLayer = () => {
+  const myInfo = useMyInfo();
   const accessToken = useTokenStore((state) => state.accessToken);
   const firstEffect = useRef(true);
   const sockets = useSocketStore((state) => state.sockets);
@@ -76,6 +78,8 @@ const SocketLayer = () => {
       message: content,
       user_id: senderId,
     }) => {
+      if (myInfo?._id === senderId) return;
+
       addChatsQueryData({ id, content, channelId, senderId, createdAt });
 
       if (chatScrollbar && isScrollTouchedBottom(chatScrollbar, 50)) {

--- a/client/src/mocks/data/users.js
+++ b/client/src/mocks/data/users.js
@@ -9,6 +9,7 @@ export const createMockUser = () => ({
   status: ['ONLINE', 'OFFLINE', 'AFK'][getRandomInt(3)],
   profileUrl: faker.image.cats(300, 300, true),
   description: faker.lorem.sentence(),
+  createdAt: '2022-12-01T21:17:09.270Z',
 });
 
 export const users = [...Array(30)].map(createMockUser);

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -48,7 +48,7 @@ const Channel = () => {
     },
   );
 
-  const { addChatsQueryData, updateChatToFailedChat, updateChatToWittenChat } =
+  const { addChatsQueryData, updateChatToFailedChat, updateChatToWrittenChat } =
     useSetChatsQuery();
   const setChatScrollbar = useRootStore((state) => state.setChatScrollbar);
   const chatScrollbar = useRootStore((state) => state.chatScrollbar);
@@ -79,7 +79,7 @@ const Channel = () => {
       }),
       ({ written }: { written: boolean }) => {
         if (written) {
-          updateChatToWittenChat({ id, channelId: roomId });
+          updateChatToWrittenChat({ id, channelId: roomId });
           return;
         }
 

--- a/client/src/pages/Friends/index.tsx
+++ b/client/src/pages/Friends/index.tsx
@@ -62,9 +62,6 @@ const Friends = () => {
         <div className="flex-1 min-w-[720px] max-w-[960px] h-[100%]">
           {TabPanel[tab]}
         </div>
-        <div className="flex w-72 h-full border-l border-line">
-          온라인, 오프라인
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Issues
- #281 

## 🤷‍♂️ Description

채팅 전송 실패시 에러 핸들링

## 📝 Primary Commits
 

- [X] 개행도 렌더링하도록 업데이트
  - [X] `\n`으로 `split`하여 요소 하나당 p태그로 래핑
  - [X] 만약 빈 문자열 `''`요소가 연속되는 경우 개행 하나로 처리하기 때문에 빈 문자열은 `<br />`을 p태그로 래핑 

- [X] `written`상태를 `-1 | boolean`으로 정의
  - [X] `undefined`로 할 경우, 모든 채팅에 대해서 적용되기 때문에 전송 처리중을 나타내는 상태로 `-1`을 추가
- [X] 소켓 연결 로직 백엔드 요구사항에 맞게 업데이트
- [X] QueryData 수동 조작하는 함수 두개 추가 (주석에 설명 넣었습니다.)
  - [X] `updateChatToWrittenChat` -> 전송한 채팅이 성공적으로 DB에 저장되었음을 나타내기 위해, 타겟 채팅을 쿼리 채팅 배열의 맨 마지막에 삽입하면서 `written`상태를 `true`로 변경합니다.
  - [X] `updateChatToFailedChat` -> 전송한 채팅이 DB 저장에 실패했음을 나타내기 위해, 타겟 채팅의 `written`상태를 `false`로 변경합니다.
- [X] 재전송 버튼은 구현하려 했으나 너무 복잡해질것 같아서 제외 
- [X] 지우기 버튼은 채팅 전송 실패시 내 화면에서 지우는 버튼

## 📷 Screenshots
- 개행

![공백](https://user-images.githubusercontent.com/79135734/206552628-4301c9ba-98a2-4adc-bf7e-f9280ae9d687.gif)

- 보내는중

![보내는중](https://user-images.githubusercontent.com/79135734/206555024-47f2044f-dc65-45f4-885e-6eb9874b65b9.PNG)

- 전송 실패 및 삭제
![전송실패 지우기](https://user-images.githubusercontent.com/79135734/206555141-7279ca28-7795-4c35-95c1-2884e364d582.gif)



## 📒 Remarks

- 채널 이동시 채팅 데이터가 언마운트되는데, 이 때 소켓 Emit Callback이 유지되는지는 의문입니다. 테스트해볼 필요 있어요.
