### PR TITLE
[Server/community] DTO를 한번에 받도록 리팩토링

### DIFF
--- a/server/apps/api/src/community/communities.controller.ts
+++ b/server/apps/api/src/community/communities.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { CommunityService } from '@api/src/community/community.service';
 import { responseForm } from '@utils/responseForm';
 import { JwtAccessGuard } from '@api/src/auth/guard';
 import { AppendUsersToCommunityDto, DeleteCommunityDto, ModifyCommunityDto } from '@community/dto';
 import { RequestUserAboutCommunityDto } from '@community/dto/request-user-about-community.dto';
+import { ReceivedData } from '@custom/decorator/ReceivedData.decorator';
 
 @Controller('api/communities')
 export class CommunitiesController {
@@ -12,73 +13,50 @@ export class CommunitiesController {
   @Get()
   @UseGuards(JwtAccessGuard)
   async getCommunities(@Req() req: any) {
-    const _id = req.user._id;
-    const result = await this.communityService.getCommunities(_id);
+    const requestUserid = req.user._id;
+    const result = await this.communityService.getCommunities(requestUserid);
     return responseForm(200, result);
   }
 
   @Post(':community_id/users')
   @UseGuards(JwtAccessGuard)
   async appendUsersToCommunity(
-    @Param('community_id') community_id: string,
-    @Body() appendUsersToCommunityDto: AppendUsersToCommunityDto,
-    @Req() req: any,
+    @ReceivedData() appendUsersToCommunityDto: AppendUsersToCommunityDto,
   ) {
-    const requestUserId = req.user._id;
-    await this.communityService.appendUsersToCommunity({
-      ...appendUsersToCommunityDto,
-      community_id,
-      requestUserId,
-    });
+    console.log(appendUsersToCommunityDto);
+    await this.communityService.appendUsersToCommunity(appendUsersToCommunityDto);
     return responseForm(200, { message: '커뮤니티 사용자 추가 완료' });
   }
 
   @Delete(':community_id')
   @UseGuards(JwtAccessGuard)
-  async deleteCommunity(@Param('community_id') community_id: string, @Req() req: any) {
-    const requestUserId = req.user._id;
-    const deleteCommunityDto: DeleteCommunityDto = { requestUserId, community_id };
+  async deleteCommunity(@ReceivedData() deleteCommunityDto: DeleteCommunityDto) {
     await this.communityService.deleteCommunity(deleteCommunityDto);
     return responseForm(200, { message: '커뮤니티 삭제 성공' });
   }
 
   @Get(':community_id/users')
   @UseGuards(JwtAccessGuard)
-  async getUsersInCommunity(@Param('community_id') community_id: string, @Req() req: any) {
-    const requestUserId = req.user._id;
-    const requestUserAboutCommunityDto: RequestUserAboutCommunityDto = {
-      community_id,
-      requestUserId,
-    };
+  async getUsersInCommunity(
+    @ReceivedData() requestUserAboutCommunityDto: RequestUserAboutCommunityDto,
+  ) {
     const result = await this.communityService.getUsersInCommunity(requestUserAboutCommunityDto);
     return responseForm(200, result);
   }
 
   @Delete(':community_id/me')
   @UseGuards(JwtAccessGuard)
-  async exitUserInCommunity(@Param('community_id') community_id: string, @Req() req: any) {
-    const requestUserId = req.user._id;
-    const requestUserAboutCommunityDto: RequestUserAboutCommunityDto = {
-      community_id,
-      requestUserId,
-    };
+  async exitUserInCommunity(
+    @ReceivedData() requestUserAboutCommunityDto: RequestUserAboutCommunityDto,
+  ) {
     await this.communityService.exitUserInCommunity(requestUserAboutCommunityDto);
     return responseForm(200, { message: '사용자 커뮤니티 탈퇴 성공' });
   }
 
   @Patch(':community_id/settings')
   @UseGuards(JwtAccessGuard)
-  async modifyCommunitySetting(
-    @Param('community_id') community_id: string,
-    @Body() modifyCommunityDto: ModifyCommunityDto,
-    @Req() req: any,
-  ) {
-    const requestUserId = req.user._id;
-    await this.communityService.modifyCommunity({
-      ...modifyCommunityDto,
-      community_id,
-      requestUserId,
-    });
+  async modifyCommunitySetting(@ReceivedData() modifyCommunityDto: ModifyCommunityDto) {
+    await this.communityService.modifyCommunity(modifyCommunityDto);
     return responseForm(200, { message: '커뮤니티 정보 수정 완료' });
   }
 }

--- a/server/apps/api/src/community/community.controller.ts
+++ b/server/apps/api/src/community/community.controller.ts
@@ -3,6 +3,8 @@ import { CommunityService } from '@api/src/community/community.service';
 import { responseForm } from '@utils/responseForm';
 import { JwtAccessGuard } from '@api/src/auth/guard';
 import { ReceivedData } from '@custom/decorator/ReceivedData.decorator';
+import { userToManagerPipe } from '@custom/pipe/userToManger.pipe';
+import { CreateCommunityDto } from '@community/dto';
 
 @Controller('api/community')
 export class CommunityController {
@@ -10,10 +12,7 @@ export class CommunityController {
 
   @Post()
   @UseGuards(JwtAccessGuard)
-  async crateCommunity(@ReceivedData() createCommunityDto) {
-    createCommunityDto['managerId'] = createCommunityDto.requestUserId;
-    delete createCommunityDto.requestUserId;
-
+  async crateCommunity(@ReceivedData(userToManagerPipe) createCommunityDto: CreateCommunityDto) {
     const result = await this.communityService.createCommunity(createCommunityDto);
     return responseForm(200, result);
   }

--- a/server/apps/api/src/community/community.controller.ts
+++ b/server/apps/api/src/community/community.controller.ts
@@ -1,8 +1,8 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { Controller, Post, UseGuards } from '@nestjs/common';
 import { CommunityService } from '@api/src/community/community.service';
 import { responseForm } from '@utils/responseForm';
 import { JwtAccessGuard } from '@api/src/auth/guard';
-import { CreateCommunityDto, ModifyCommunityDto } from './dto';
+import { ReceivedData } from '@custom/decorator/ReceivedData.decorator';
 
 @Controller('api/community')
 export class CommunityController {
@@ -10,12 +10,11 @@ export class CommunityController {
 
   @Post()
   @UseGuards(JwtAccessGuard)
-  async crateCommunity(@Body() createCommunityDto: CreateCommunityDto, @Req() req: any) {
-    const managerId = req.user._id;
-    const result = await this.communityService.createCommunity({
-      managerId,
-      ...createCommunityDto,
-    });
+  async crateCommunity(@ReceivedData() createCommunityDto) {
+    createCommunityDto['managerId'] = createCommunityDto.requestUserId;
+    delete createCommunityDto.requestUserId;
+
+    const result = await this.communityService.createCommunity(createCommunityDto);
     return responseForm(200, result);
   }
 }

--- a/server/apps/api/src/community/community.service.ts
+++ b/server/apps/api/src/community/community.service.ts
@@ -23,9 +23,9 @@ export class CommunityService {
     private readonly channelRepository: ChannelRepository,
   ) {}
 
-  async getCommunities(_id: string) {
+  async getCommunities(requestUserId: string) {
     const communitiesInfo = [];
-    const user = await this.userRepository.findById(_id);
+    const user = await this.userRepository.findById(requestUserId);
     if (user.communities === undefined || Object.keys(user.communities).length == 0) {
       return { communities: communitiesInfo };
     }
@@ -151,7 +151,7 @@ export class CommunityService {
     if (community.managerId != modifyCommunityDto.requestUserId) {
       throw new BadRequestException('사용자의 커뮤니티 수정 권한이 없습니다.');
     }
-    const { managerId, community_id, ...updateField } = modifyCommunityDto;
+    const { community_id, ...updateField } = modifyCommunityDto;
     // TODO: 꼭 기다려줘야하는지 생각해보기
     return await this.communityRepository.updateOne({ _id: community_id }, updateField);
   }

--- a/server/apps/api/src/community/dto/append-participants-to-community.dto.ts
+++ b/server/apps/api/src/community/dto/append-participants-to-community.dto.ts
@@ -1,19 +1,12 @@
-import {
-  ArrayNotEmpty,
-  IsArray,
-  IsNotEmpty,
-  IsNumber,
-  IsOptional,
-  IsString,
-} from 'class-validator';
+import { ArrayNotEmpty, IsArray, IsMongoId, IsNotEmpty } from 'class-validator';
 
 export class AppendUsersToCommunityDto {
-  @IsOptional()
-  @IsString()
+  @IsNotEmpty()
+  @IsMongoId()
   community_id: string;
 
-  @IsOptional()
-  @IsString()
+  @IsNotEmpty()
+  @IsMongoId()
   requestUserId: string;
 
   @IsNotEmpty()

--- a/server/apps/api/src/community/dto/create-community.dto.ts
+++ b/server/apps/api/src/community/dto/create-community.dto.ts
@@ -1,4 +1,5 @@
 import { IsMongoId, IsNotEmpty, IsOptional, IsString, Length } from 'class-validator';
+import { Expose } from 'class-transformer';
 
 export class CreateCommunityDto {
   @IsNotEmpty()
@@ -6,12 +7,9 @@ export class CreateCommunityDto {
   @Length(2, 20)
   name: string;
 
-  @IsOptional()
   @IsMongoId()
-  requestUserId: string;
-
-  @IsOptional()
-  @IsMongoId()
+  @IsNotEmpty()
+  @Expose({ name: 'requestUserId' })
   managerId: string;
 
   @IsOptional()

--- a/server/apps/api/src/community/dto/create-community.dto.ts
+++ b/server/apps/api/src/community/dto/create-community.dto.ts
@@ -1,12 +1,17 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsMongoId, IsNotEmpty, IsOptional, IsString, Length } from 'class-validator';
 
 export class CreateCommunityDto {
   @IsNotEmpty()
   @IsString()
+  @Length(2, 20)
   name: string;
 
   @IsOptional()
-  @IsString()
+  @IsMongoId()
+  requestUserId: string;
+
+  @IsOptional()
+  @IsMongoId()
   managerId: string;
 
   @IsOptional()

--- a/server/apps/api/src/community/dto/delete-community.dto.ts
+++ b/server/apps/api/src/community/dto/delete-community.dto.ts
@@ -1,11 +1,11 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsMongoId, IsNotEmpty } from 'class-validator';
 
 export class DeleteCommunityDto {
   @IsNotEmpty()
-  @IsString()
+  @IsMongoId()
   community_id: string;
 
   @IsNotEmpty()
-  @IsString()
+  @IsMongoId()
   requestUserId: string;
 }

--- a/server/apps/api/src/community/dto/modify-community.dto.ts
+++ b/server/apps/api/src/community/dto/modify-community.dto.ts
@@ -1,16 +1,20 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class ModifyCommunityDto {
-  @IsOptional()
-  @IsString()
+  @IsNotEmpty()
+  @IsMongoId()
   community_id: string;
+
+  @IsNotEmpty()
+  @IsMongoId()
+  requestUserId: string;
 
   @IsOptional()
   @IsString()
   name: string;
 
   @IsOptional()
-  @IsString()
+  @IsMongoId()
   managerId: string;
 
   @IsOptional()
@@ -20,8 +24,4 @@ export class ModifyCommunityDto {
   @IsOptional()
   @IsString()
   profileUrl: string;
-
-  @IsOptional()
-  @IsString()
-  requestUserId: string;
 }

--- a/server/apps/api/src/community/dto/request-user-about-community.dto.ts
+++ b/server/apps/api/src/community/dto/request-user-about-community.dto.ts
@@ -1,11 +1,11 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsMongoId, IsNotEmpty } from 'class-validator';
 
 export class RequestUserAboutCommunityDto {
   @IsNotEmpty()
-  @IsString()
+  @IsMongoId()
   community_id: string;
 
   @IsNotEmpty()
-  @IsString()
+  @IsMongoId()
   requestUserId: string;
 }


### PR DESCRIPTION
## Issues
- #291 

## 🤷‍♂️ Description

- 커뮤니티에서 클라이언트로부터 오는 데이터(Param, Body, Req)를 커스텀 데코레이터를 사용하여 DTO를 한번에 받도록 리팩토링

- DTO 수정
  - mongoId를 받아오는 값들 `@IsString` -> `@IsMongoId`로 수정
  - @ReceivedData()로 한번에 데이터를 받아와서 필수 값들 `@IsOptional` -> `@IsNotEmpty`로 수정

