### PR TITLE
[CLIENT] 채널 초대 소켓 이벤트

### DIFF
--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -65,8 +65,9 @@ const ChatItem: FC<Props> = ({
           <div className="grow">
             <div className="flex gap-2 items-center text-s16 mb-2">
               <span
-                className={`font-bold ${isSystem ? 'text-primary' : 'text-indigo'
-                  } ${contentClassnames}`}
+                className={`font-bold ${
+                  isSystem ? 'text-primary' : 'text-indigo'
+                } ${contentClassnames}`}
               >
                 {user.nickname}
               </span>

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -1,11 +1,14 @@
-import type { ReceiveChatHandler } from '@/socketEvents';
+import type {
+  ReceiveChatHandler,
+  InvitedToChannelHandler,
+} from '@/socketEvents';
 import type { CommunitySummaries } from '@apis/community';
 import type { Sockets } from '@stores/socketStore';
 
 import { SOCKET_URL } from '@constants/url';
 import { useMyInfoQueryData } from '@hooks/auth';
+import { useSetChannelQueryData } from '@hooks/channel';
 import { useSetChatsQueryData } from '@hooks/chat';
-import { useInvalidateCommunitiesQuery } from '@hooks/community';
 import { useRootStore } from '@stores/rootStore';
 import { useSocketStore } from '@stores/socketStore';
 import { useTokenStore } from '@stores/tokenStore';
@@ -32,8 +35,7 @@ const SocketLayer = () => {
   const chatScrollbar = useRootStore((state) => state.chatScrollbar);
 
   const { addChatsQueryData } = useSetChatsQueryData();
-  const invalidateCommunitiesQuery = useInvalidateCommunitiesQuery();
-  // const { addChannelQueryData } = useSetChannelQueryData();
+  const { addChannelQueryData } = useSetChannelQueryData();
 
   useEffect(() => {
     const opts = {
@@ -92,17 +94,12 @@ const SocketLayer = () => {
       }
     };
 
-    const handleInvitedToChannel = () => {
-      invalidateCommunitiesQuery();
+    const handleInvitedToChannel: InvitedToChannelHandler = ({
+      communityId,
+      ...joinedChannel
+    }) => {
+      addChannelQueryData(communityId, joinedChannel);
     };
-
-    // TODO: 커뮤니티 아이디 받아오면 setQueryData 해줄 수 있음
-    // const handleInvitedToChannel: InvitedToChannelHandler = ({
-    //   communityId,
-    //   ...joinedChannel
-    // }) => {
-    //   addChannelQueryData(communityId, joinedChannel);
-    // };
 
     // const interval = setInterval(() => {
     //   handleReceiveChat({

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -5,6 +5,7 @@ import type { Sockets } from '@stores/socketStore';
 import { SOCKET_URL } from '@constants/url';
 import { useMyInfoQueryData } from '@hooks/auth';
 import { useSetChatsQueryData } from '@hooks/chat';
+import { useInvalidateCommunitiesQuery } from '@hooks/community';
 import { useRootStore } from '@stores/rootStore';
 import { useSocketStore } from '@stores/socketStore';
 import { useTokenStore } from '@stores/tokenStore';
@@ -31,6 +32,8 @@ const SocketLayer = () => {
   const chatScrollbar = useRootStore((state) => state.chatScrollbar);
 
   const { addChatsQueryData } = useSetChatsQueryData();
+  const invalidateCommunitiesQuery = useInvalidateCommunitiesQuery();
+  // const { addChannelQueryData } = useSetChannelQueryData();
 
   useEffect(() => {
     const opts = {
@@ -89,6 +92,18 @@ const SocketLayer = () => {
       }
     };
 
+    const handleInvitedToChannel = () => {
+      invalidateCommunitiesQuery();
+    };
+
+    // TODO: 커뮤니티 아이디 받아오면 setQueryData 해줄 수 있음
+    // const handleInvitedToChannel: InvitedToChannelHandler = ({
+    //   communityId,
+    //   ...joinedChannel
+    // }) => {
+    //   addChannelQueryData(communityId, joinedChannel);
+    // };
+
     // const interval = setInterval(() => {
     //   handleReceiveChat({
     //     id: faker.datatype.uuid(),
@@ -116,6 +131,8 @@ const SocketLayer = () => {
           console.error(err.message); // Not Authorized
         }
       });
+
+      socket.on(SOCKET_EVENTS.INVITED_TO_CHANNEL, handleInvitedToChannel);
     });
 
     // 이벤트 off
@@ -125,6 +142,7 @@ const SocketLayer = () => {
       socketArr.forEach((socket) => {
         socket.off(SOCKET_EVENTS.RECEIVE_CHAT);
         socket.off(SOCKET_EVENTS.INVALID_TOKEN);
+        socket.off(SOCKET_EVENTS.INVITED_TO_CHANNEL);
       });
     };
   }, [sockets, chatScrollbar]);

--- a/client/src/pages/Friends/index.tsx
+++ b/client/src/pages/Friends/index.tsx
@@ -47,7 +47,6 @@ const Friends = () => {
             <li
               key={_tab}
               className={`${
-                // 강제 포맷 방지용 주석
                 tab === _tab ? 'text-indigo' : 'text-placeholder'
               } font-bold text-s20`}
             >

--- a/client/src/socketEvents/index.ts
+++ b/client/src/socketEvents/index.ts
@@ -1,8 +1,11 @@
+import type { User } from '@apis/user';
+
 export const SOCKET_EVENTS = {
   JOIN_CHANNEL: 'join',
   SEND_CHAT: 'new-message',
   RECEIVE_CHAT: 'new-message',
   INVALID_TOKEN: 'connect_error',
+  INVITE_USERS_TO_CHANNEL: 'invite-users-to-channel',
 } as const;
 
 export const joinChannelsPayload = (channelIds: string[]) => ({
@@ -46,3 +49,27 @@ export type ReceiveChatHandler = ({
   message,
   time,
 }: ReceiveChatPayload) => void;
+
+/* ======================= [ 채널 초대 보내기 ] ====================== */
+export interface InviteUsersToChannelPayloadParameter {
+  communityId: string;
+  channelId: string;
+  users: Array<User['_id']>;
+}
+
+export const inviteUsersToChannelPayload = ({
+  communityId,
+  channelId,
+  users,
+}: InviteUsersToChannelPayloadParameter) => ({
+  community_id: communityId,
+  channel_id: channelId,
+  users,
+});
+
+export interface InviteUsersToChannelResponse {
+  isSuccess: boolean;
+}
+export type InviteUsersToChannelCallback = (
+  response: InviteUsersToChannelResponse,
+) => void;

--- a/client/src/socketEvents/index.ts
+++ b/client/src/socketEvents/index.ts
@@ -1,3 +1,5 @@
+import type { JoinedChannel } from '@apis/channel';
+import type { CommunitySummary } from '@apis/community';
 import type { User } from '@apis/user';
 
 export const SOCKET_EVENTS = {
@@ -6,6 +8,7 @@ export const SOCKET_EVENTS = {
   RECEIVE_CHAT: 'new-message',
   INVALID_TOKEN: 'connect_error',
   INVITE_USERS_TO_CHANNEL: 'invite-users-to-channel',
+  INVITED_TO_CHANNEL: 'invited-to-channel',
 } as const;
 
 export const joinChannelsPayload = (channelIds: string[]) => ({
@@ -72,4 +75,12 @@ export interface InviteUsersToChannelResponse {
 }
 export type InviteUsersToChannelCallback = (
   response: InviteUsersToChannelResponse,
+) => void;
+
+/* ======================= [ 채널 초대 받음 ] ====================== */
+export interface InvitedToChannelPayload extends JoinedChannel {
+  communityId: CommunitySummary['_id'];
+}
+export type InvitedToChannelHandler = (
+  payload: InvitedToChannelPayload,
 ) => void;


### PR DESCRIPTION
## Issues
- #295 

## 🤷‍♂️ Description

- 채널 초대 시 API 요청하지 않고 소켓 이벤트 발생시키는 것으로 변경
- 채널 초대 받으면 queryClient에 반영하도록 함

 
## 📒 Remarks
~~채널 초대 받은 클라이언트에서 queryClient에 반영하는 방법~~
- ~~현재는 커뮤니티 아이디를 받아오지 않으므로 `invalidateQueries`로 반영함~~
- ~~커뮤니티 아이디 받으면 `setQueryData`로 반영하도록 바꿔야함~~
=> 커뮤니티 아이디 받으므로 `setQueryData`로 `queryClient`에 반영