### PR TITLE
[Server/channel] Bot을 channel 서비스에서 다른 서비스로 분리

### DIFF
--- a/server/apps/api/src/channel/bot.service.ts
+++ b/server/apps/api/src/channel/bot.service.ts
@@ -1,0 +1,36 @@
+import { BOT_ID } from '@utils/def';
+import { makeChat } from '@chat-list/helper/makeChat';
+import { ChatListRespository } from '@repository/chat-list.respository';
+import { ChannelRepository } from '@repository/channel.repository';
+import { Injectable } from '@nestjs/common';
+
+const makeBotMessageDate = () =>
+  new Date().toLocaleDateString('ko', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  });
+
+@Injectable()
+export class BotService {
+  constructor(
+    private readonly chatListRepository: ChatListRespository,
+    private readonly channelRepository: ChannelRepository,
+  ) {}
+  async infoMakeChannel(channel_id, nickname) {
+    const botMessage = {
+      channel_id: channel_id,
+      type: 'TEXT',
+      content: `${nickname}님이 이 채널을 ${makeBotMessageDate()}에 생성했습니다.`,
+      senderId: BOT_ID,
+    } as const;
+    const newChatList = await this.chatListRepository.create({
+      chat: [makeChat(0, botMessage)],
+    });
+    await this.channelRepository.addArrAtArr({ _id: channel_id }, 'chatLists', [
+      newChatList._id.toString(),
+    ]);
+  }
+}

--- a/server/apps/api/src/channel/bot.service.ts
+++ b/server/apps/api/src/channel/bot.service.ts
@@ -22,7 +22,7 @@ export class BotService {
   async infoMakeChannel(channel_id, nickname) {
     const botMessage = {
       channel_id: channel_id,
-      type: 'TEXT',
+      type: 'SYSTEM',
       content: `${nickname}님이 이 채널을 ${makeBotMessageDate()}에 생성했습니다.`,
       senderId: BOT_ID,
     } as const;

--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -5,15 +5,17 @@ import { CreateChannelDto } from '@channel/dto';
 import { responseForm } from '@utils/responseForm';
 import { ReceivedData } from '@custom/decorator/ReceivedData.decorator';
 import { userToManagerPipe } from '@custom/pipe/userToManger.pipe';
+import { BotService } from '@channel/bot.service';
 
 @Controller('api/channel')
 export class ChannelController {
-  constructor(private channelService: ChannelService) {}
+  constructor(private channelService: ChannelService, private botService: BotService) {}
 
   @Post()
   @UseGuards(JwtAccessGuard)
   async createChannel(@ReceivedData(userToManagerPipe) createChannelDto: CreateChannelDto) {
     const newChannel = await this.channelService.createChannel(createChannelDto);
+    await this.botService.infoMakeChannel(newChannel._id, createChannelDto.nickname);
 
     delete newChannel.users;
     return responseForm(200, newChannel);

--- a/server/apps/api/src/channel/channel.module.ts
+++ b/server/apps/api/src/channel/channel.module.ts
@@ -12,6 +12,7 @@ import { UserModule } from '@user/user.module';
 import { ChannelsController } from '@channel/channels.controller';
 import { ChatListModule } from '@chat-list/chat-list.module';
 import { ChatListRespository } from '@repository/chat-list.respository';
+import { BotService } from '@channel/bot.service';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { ChatListRespository } from '@repository/chat-list.respository';
     CommunityRepository,
     UserRepository,
     ChatListRespository,
+    BotService,
   ],
   exports: [MongooseModule],
 })

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -14,7 +14,6 @@ import { ExitChannelDto } from '@channel/dto/exit-channel.dto';
 import { getChannelBasicInfo, getChannelToUserForm } from '@channel/helper';
 import { getUserBasicInfo } from '@user/helper/getUserBasicInfo';
 import { ChatListRespository } from '@repository/chat-list.respository';
-import { BotService } from '@channel/bot.service';
 
 @Injectable()
 export class ChannelService {
@@ -23,7 +22,6 @@ export class ChannelService {
     private readonly communityRepository: CommunityRepository,
     private readonly chatListRepository: ChatListRespository,
     private readonly userRepository: UserRepository,
-    private readonly botService: BotService,
   ) {}
 
   async createChannel(createChannelDto: CreateChannelDto) {
@@ -44,9 +42,6 @@ export class ChannelService {
       // 공개 채널일 경우 : 채널 유저에 커뮤니티 사용자 모두 존재
       await this.addUserToChannel(community._id, channel._id, community.users);
     }
-    const user = await this.userRepository.findById(managerId);
-
-    this.botService.infoMakeChannel(channel._id, user.nickname);
 
     return getChannelBasicInfo(channel);
   }

--- a/server/apps/api/src/channel/dto/create-channel.dto.ts
+++ b/server/apps/api/src/channel/dto/create-channel.dto.ts
@@ -18,6 +18,10 @@ export class CreateChannelDto {
 
   @IsString()
   @IsNotEmpty()
+  nickname: string;
+
+  @IsString()
+  @IsNotEmpty()
   type: 'Channel' | 'DM';
 
   @IsBoolean()

--- a/server/apps/api/src/channel/helper/getChannelBasicInfo.ts
+++ b/server/apps/api/src/channel/helper/getChannelBasicInfo.ts
@@ -2,7 +2,7 @@ export const getChannelBasicInfo = (channel) => {
   return {
     _id: channel._id,
     name: channel.name,
-    community_id: channel.community_id,
+    communityId: channel.communityId,
     managerId: channel.managerId,
     description: channel.description,
     type: channel.type,

--- a/server/apps/api/src/chat-list/dto/restore-message.dto.ts
+++ b/server/apps/api/src/chat-list/dto/restore-message.dto.ts
@@ -9,7 +9,7 @@ export class RestoreMessageDto {
 
   @IsString()
   @IsNotEmpty()
-  type: 'TEXT' | 'IMAGE';
+  type: 'TEXT' | 'IMAGE' | 'SYSTEM';
 
   @IsString()
   @IsNotEmpty()

--- a/server/apps/api/src/main.ts
+++ b/server/apps/api/src/main.ts
@@ -20,6 +20,7 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       validateCustomDecorators: true,
+      whitelist: true,
     }),
   );
   app.useGlobalInterceptors(new SentryInterceptor(app.get(WINSTON_MODULE_NEST_PROVIDER)));

--- a/server/custom/decorator/ReceivedData.decorator.ts
+++ b/server/custom/decorator/ReceivedData.decorator.ts
@@ -7,5 +7,6 @@ export const ReceivedData = createParamDecorator((data: unknown, ctx: ExecutionC
     ...req.params,
     ...req.query,
     requestUserId: req.user._id,
+    nickname: req.user.nickname,
   };
 });

--- a/server/utils/def.ts
+++ b/server/utils/def.ts
@@ -1,5 +1,5 @@
 export const STATUS = ['ONLINE', 'OFFLINE', 'AFK'];
 export const PROVIDER = ['ASNITY', 'GITHUB'];
 export const CHANNEL_TYPE = ['CHANNEL', 'DM'];
-export const CHAT_TYPE = ['TEXT', 'IMAGE'];
+export const CHAT_TYPE = ['TEXT', 'IMAGE', 'SYSTEM'];
 export const BOT_ID = '639045fc61d68253e03c50da';


### PR DESCRIPTION
## Issues
- #279 

## 🤷‍♂️ Description

봇 메세지 처리 로직을 channel 서비스에서 다른 서비스로 분리

## 📒 Remarks

아까 나누고 싶다던 의견입니다.
봇을 원래 helper에 넣으려고 했는데, repository에 접근을 해서 로직을 수행하기 때문에 service로 만들었습니다. 
service에서 service를 불러오는 것 같아 좋은 코드라 생각이 들지는 않는데 어떻게 생각하시나요??
아니면 controller에서 두개의 service로 불러오는 방식도 괜찮을꺼 같아요.