### PR TITLE
[Server/channel] 채널 이탈 시 버그 해결

### DIFF
--- a/server/apps/api/src/channel/helper/addObjectForm.ts
+++ b/server/apps/api/src/channel/helper/addObjectForm.ts
@@ -1,6 +1,5 @@
 export function getChannelToUserForm(community_id: string, channel_id: string) {
   return {
-    [`communities.${community_id.toString()}._id`]: community_id,
     [`communities.${community_id.toString()}.channels.${channel_id.toString()}`]: new Date(),
   };
 }


### PR DESCRIPTION
## 🤷‍♂️ Description

- 채널 이탈 시 communities:_id가 사라지는 이슈 해결

## 📒 Remarks
- 이슈 원인 : delete할 때 addObjectForm.ts를 사용하여 _id도 지워졌습니다.
- 해결 : 방금 이슈의 해결책으로 착각하여 생성한 addObjectForm.ts의 _id를 넣어주는 부분을 제거했습니다.
- 제거해도 괜찮은 이유 : 방금 이슈는 community에 사용자가 존재하지 않아서 발생한건데 community에 존재하지 않으면 에러를 발생하게 해서 해결했습니다.