### PR TITLE
[CLIENT] 안 읽은 메시지 Gnb와 사이드바에 표시

### DIFF
--- a/client/src/apis/channel.ts
+++ b/client/src/apis/channel.ts
@@ -106,3 +106,26 @@ export const inviteChannel: InviteChannel = ({
     })
     .then((response) => response.data.result);
 };
+
+export interface UpdateLastReadRequest {
+  channelId: string;
+  communityId: string;
+}
+
+export interface UpdateLastReadResult {
+  message: string;
+}
+export type UpdateLastReadResponse = SuccessResponse<UpdateLastReadResult>;
+export type UpdateLastRead = (
+  fields: UpdateLastReadRequest,
+) => Promise<UpdateLastReadResult>;
+
+export const updateLastRead: UpdateLastRead = ({ channelId, communityId }) => {
+  const endPoint = `/api/channels/${channelId}/lastRead`;
+
+  return tokenAxios
+    .patch<UpdateLastReadResponse>(endPoint, {
+      community_id: communityId,
+    })
+    .then((response) => response.data.result);
+};

--- a/client/src/components/Avatar/index.tsx
+++ b/client/src/components/Avatar/index.tsx
@@ -3,7 +3,7 @@ import type { ReactNode, FC } from 'react';
 
 import React, { memo } from 'react';
 
-type BadgeType = keyof typeof USER_STATUS;
+type BadgeType = keyof typeof USER_STATUS | 'NEW';
 
 export interface Props {
   name: string;
@@ -49,6 +49,7 @@ const BADGE_COLOR: Record<BadgeType, string> = {
   ONLINE: 'bg-success',
   AFK: 'bg-error',
   OFFLINE: 'bg-label',
+  NEW: 'bg-indigo',
 };
 
 const Avatar: FC<Props> = ({

--- a/client/src/components/ChannelItem/index.tsx
+++ b/client/src/components/ChannelItem/index.tsx
@@ -15,13 +15,18 @@ const ChannelItem: FC<Props> = ({ channel, communityId, ...restProps }) => {
     <li {...restProps}>
       <Link
         to={`/communities/${communityId}/channels/${channel._id}`}
-        className="w-full py-[6px] pl-[40px]"
+        className="flex w-full justify-between items-center py-[6px] pl-[40px] pr-[15px]"
       >
         <ChannelName
           isPrivate={channel.isPrivate}
           name={channel.name}
           className="flex items-center gap-[5px] select-none w-full"
         />
+        {channel.lastRead && (
+          <span className="py-1 px-2 rounded-2xl bg-primary text-offWhite text-s12 tracking-tighter font-bold shadow-lg">
+            new
+          </span>
+        )}
       </Link>
     </li>
   );

--- a/client/src/constants/endPoint.ts
+++ b/client/src/constants/endPoint.ts
@@ -24,6 +24,7 @@ const endPoint = {
   getCommunityUsers: (communityId: string) =>
     `/api/communities/${communityId}/users` as const,
   getChats: (channelId: string) => `/api/channels/${channelId}/message`,
+  updateLastRead: (channelId: string) => `/api/channels/${channelId}/lastRead`,
 } as const;
 
 export default endPoint;

--- a/client/src/hooks/channel.ts
+++ b/client/src/hooks/channel.ts
@@ -1,4 +1,5 @@
 import type {
+  UpdateLastReadResult,
   Channel,
   CreateChannelRequest,
   CreateChannelResult,
@@ -20,6 +21,7 @@ import {
   leaveChannel,
   createChannel,
   getChannel,
+  updateLastRead,
 } from '@apis/channel';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
@@ -158,6 +160,15 @@ export const useInviteChannelMutation = (
 ) => {
   const key = queryKeyCreator.channel.inviteChannel();
   const mutation = useMutation(key, inviteChannel, { ...options });
+
+  return mutation;
+};
+
+export const useUpdateLastReadMutation = (
+  options?: MutationOptions<UpdateLastReadResult, unknown, unknown>,
+) => {
+  const key = queryKeyCreator.channel.updateLastRead();
+  const mutation = useMutation(key, updateLastRead, { ...options });
 
   return mutation;
 };

--- a/client/src/hooks/channel.ts
+++ b/client/src/hooks/channel.ts
@@ -24,6 +24,7 @@ import {
   updateLastRead,
 } from '@apis/channel';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import produce from 'immer';
 import { useCallback } from 'react';
 
 import queryKeyCreator from '@/queryKeyCreator';
@@ -143,7 +144,32 @@ export const useSetChannelQueryData = () => {
     });
   };
 
-  return { addChannelQueryData, removeChannelQueryData };
+  const updateLastReadInChannelQueryData = (
+    communityId: string,
+    channelId: string,
+    lastRead: boolean,
+  ) => {
+    queryClient.setQueryData<CommunitySummaries>(key, (communities) => {
+      return produce(communities, (draft: CommunitySummaries) => {
+        const community = draft.find(
+          (_community) => _community._id === communityId,
+        );
+        const channel = community?.channels.find(
+          (_channel) => _channel._id === channelId,
+        );
+
+        if (!channel) return;
+
+        channel.lastRead = lastRead;
+      });
+    });
+  };
+
+  return {
+    addChannelQueryData,
+    removeChannelQueryData,
+    updateLastReadInChannelQueryData,
+  };
 };
 
 export const useLeaveChannelMutation = (

--- a/client/src/hooks/channel.ts
+++ b/client/src/hooks/channel.ts
@@ -40,12 +40,12 @@ export const useInvalidateChannelQuery = (channelId: string) => {
   const queryClient = useQueryClient();
   const key = queryKeyCreator.channel.detail(channelId);
 
-  const invalidte = useCallback(
+  const invalidate = useCallback(
     () => queryClient.invalidateQueries(key),
     [queryClient, key],
   );
 
-  return invalidte;
+  return invalidate;
 };
 
 export const usePrefetchChannelQuery = (channelId: string) => {

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -38,7 +38,7 @@ type AddChatsQueryData = ({
   written?: boolean | -1;
 }) => void;
 
-type UpdateChatQueryDataToWrittenChat = ({
+type UpdateChatToWrittenChat = ({
   id,
   channelId,
 }: {
@@ -46,8 +46,8 @@ type UpdateChatQueryDataToWrittenChat = ({
   channelId: string;
 }) => void;
 
-type UpdateChatQueryDataToFailedChat = UpdateChatQueryDataToWrittenChat;
-type RemoveChatQueryData = UpdateChatQueryDataToWrittenChat;
+type UpdateChatToFailedChat = UpdateChatToWrittenChat;
+type RemoveChatQueryData = UpdateChatToWrittenChat;
 
 export const useSetChatsQueryData = () => {
   const queryClient = useQueryClient();
@@ -86,7 +86,7 @@ export const useSetChatsQueryData = () => {
   /**
    * Optimistic Updates한 채팅의 id와 채널 id를 받아서, 해당 채팅의 written 프로퍼티를 true로 변경시킨다,
    */
-  const updateChatQueryDataToWrittenChat: UpdateChatQueryDataToWrittenChat = ({
+  const updateChatToWrittenChat: UpdateChatToWrittenChat = ({
     id,
     channelId,
   }) => {
@@ -110,7 +110,7 @@ export const useSetChatsQueryData = () => {
   /**
    * Optimistic Updates한 채팅의 id와 채널 id를 받아서, 해당 채팅의 written 프로퍼티를 false로 변경시킨다.
    */
-  const updateChatQueryDataToFailedChat: UpdateChatQueryDataToFailedChat = ({
+  const updateChatToFailedChat: UpdateChatToFailedChat = ({
     id,
     channelId,
   }) => {
@@ -156,8 +156,8 @@ export const useSetChatsQueryData = () => {
 
   return {
     addChatsQueryData,
-    updateChatQueryDataToWrittenChat,
-    updateChatQueryDataToFailedChat,
+    updateChatToWrittenChat,
+    updateChatToFailedChat,
     removeChatQueryData,
   };
 };

--- a/client/src/layouts/Gnb/index.tsx
+++ b/client/src/layouts/Gnb/index.tsx
@@ -100,6 +100,9 @@ const Gnb = () => {
             ) : (
               communitiesQuery.data?.map((community) => {
                 const { _id, name, profileUrl } = community;
+                const existUnreadChat = community.channels.some(
+                  (channel) => channel.lastRead,
+                );
 
                 return (
                   <li key={_id}>
@@ -113,6 +116,9 @@ const Gnb = () => {
                           size="sm"
                           variant="rectangle"
                           profileUrl={profileUrl}
+                          badge={existUnreadChat}
+                          badgePosition="top-left"
+                          status="NEW"
                         />
                       </Link>
                     </GnbItemContainer>

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -35,7 +35,8 @@ const SocketLayer = () => {
   const chatScrollbar = useRootStore((state) => state.chatScrollbar);
 
   const { addChatsQueryData } = useSetChatsQueryData();
-  const { addChannelQueryData } = useSetChannelQueryData();
+  const { addChannelQueryData, updateLastReadInChannelQueryData } =
+    useSetChannelQueryData();
 
   useEffect(() => {
     const opts = {
@@ -77,6 +78,7 @@ const SocketLayer = () => {
     if (firstEffect.current) return undefined;
 
     const handleReceiveChat: ReceiveChatHandler = ({
+      // communityId,
       id,
       channelId,
       time: createdAt,
@@ -92,6 +94,15 @@ const SocketLayer = () => {
           chatScrollbar?.scrollToBottom();
         });
       }
+
+      const groups = window.location.pathname.match(
+        /\/communities\/(?<communityId>\w+)\/channels\/(?<roomId>\w+)/u,
+      )?.groups as { communityId?: string; roomId?: string };
+
+      if (channelId !== groups?.roomId)
+        // 현재 communityId 보내주지 않으므로 첫번째 커뮤니티로 넣어줌
+        // TODO: 보내주는 communityId를 updateLastRead의 첫번째 인자로 넘겨야함
+        updateLastReadInChannelQueryData(communityIds[0], channelId, true);
     };
 
     const handleInvitedToChannel: InvitedToChannelHandler = ({

--- a/client/src/mocks/handlers/Channel.js
+++ b/client/src/mocks/handlers/Channel.js
@@ -117,4 +117,27 @@ const InviteChannel = rest.post(
   },
 );
 
-export default [GetChannel, CreateChannel, LeaveChannel, InviteChannel];
+const updateLastReadEndPoint = API_URL + endPoint.updateLastRead(':channelId');
+const UpdateLastRead = rest.patch(updateLastReadEndPoint, (req, res, ctx) => {
+  const ERROR = false;
+
+  const errorResponse = res(...createErrorContext(ctx));
+  const successResponse = res(
+    ...createSuccessContext(ctx, 200, 500, {
+      statusCode: 200,
+      result: {
+        message: 'Last Read 업데이트 성공!',
+      },
+    }),
+  );
+
+  return ERROR ? errorResponse : successResponse;
+});
+
+export default [
+  GetChannel,
+  CreateChannel,
+  LeaveChannel,
+  InviteChannel,
+  UpdateLastRead,
+];

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -48,11 +48,8 @@ const Channel = () => {
     },
   );
 
-  const {
-    addChatsQueryData,
-    updateChatQueryDataToFailedChat,
-    updateChatQueryDataToWrittenChat,
-  } = useSetChatsQueryData();
+  const { addChatsQueryData, updateChatToFailedChat, updateChatToWrittenChat } =
+    useSetChatsQueryData();
   const setChatScrollbar = useRootStore((state) => state.setChatScrollbar);
   const chatScrollbar = useRootStore((state) => state.chatScrollbar);
 
@@ -82,11 +79,11 @@ const Channel = () => {
       }),
       ({ written }: { written: boolean }) => {
         if (written) {
-          updateChatQueryDataToWrittenChat({ id, channelId: roomId });
+          updateChatToWrittenChat({ id, channelId: roomId });
           return;
         }
 
-        updateChatQueryDataToFailedChat({ id, channelId: roomId });
+        updateChatToFailedChat({ id, channelId: roomId });
       },
     );
 

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -5,7 +5,11 @@ import ChatList from '@components/ChatList';
 import Spinner from '@components/Spinner';
 import { faker } from '@faker-js/faker';
 import { useMyInfoQueryData } from '@hooks/auth';
-import { useChannelWithUsersMapQuery } from '@hooks/channel';
+import {
+  useChannelWithUsersMapQuery,
+  useSetChannelQueryData,
+  useUpdateLastReadMutation,
+} from '@hooks/channel';
 import { useChatsInfiniteQuery, useSetChatsQueryData } from '@hooks/chat';
 import useIntersectionObservable from '@hooks/useIntersectionObservable';
 import ChannelUserStatus from '@layouts/ChannelUserStatus';
@@ -93,6 +97,20 @@ const Channel = () => {
       });
     }
   };
+
+  const { updateLastReadInChannelQueryData } = useSetChannelQueryData();
+  const updateLastReadMutation = useUpdateLastReadMutation({
+    onSuccess: () => {
+      updateLastReadInChannelQueryData(communityId, roomId, false);
+    },
+  });
+
+  useEffect(() => {
+    updateLastReadMutation.mutate({ communityId, channelId: roomId });
+
+    return () =>
+      updateLastReadMutation.mutate({ communityId, channelId: roomId });
+  }, [communityId, roomId]);
 
   useEffect(() => {
     if (scrollbarContainerRef.current !== chatScrollbar) {

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -40,6 +40,7 @@ const channelQueryKey = {
   createChannel: () => ['createChannel'] as const,
   leaveChannel: () => ['leaveChannel'] as const,
   inviteChannel: () => ['inviteChannel'] as const,
+  updateLastRead: () => ['updateLastRead'] as const,
 };
 
 const chatQueryKey = {


### PR DESCRIPTION
## Issues
- #315 

## 🤷‍♂️ Description

- 채널 입장, 퇴장시 방문 시각을 업데이트하는 API 요청을 보낸다.
- 안 읽은 메시지가 있으면 Gnb와 사이드바에 표시한다.
- 새로 들어오는 메시지가 있을 때 현재 보고 있는 채널이 아니면 안 읽은 메시지가 있다고 Gnb와 사이드바에 표시한다.


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 채널 페이지 마운트, 언마운트시 방문 시각 업데이트
- [X] 안 읽은 메시지가 있으면 Gnb와 사이드바에 플래그 표시
- [X] 새로 들어오는 메시지를 현재 보고 있지 않다면 Gnb와 사이드바에 플래그 표시


## 📷 Screenshots
 
![Animation](https://user-images.githubusercontent.com/57662010/206875358-e6b40668-98e6-4103-b33e-261135e15c87.gif)

## 📒 Remarks

- 현재 방문 시각 업데이트하는 API가 엔드포인트만 뚫려있고 로직은 구현이 안되어있음 그래서 읽어도 refetch해오면 다시 플래그가 띄워짐
- `lastRead` 프로퍼티를 `existUnreadChat`으로 바꾼다고 함 근데 API에 반영이 안되어있음 반영 후에 바꿔줘야함
- **채널 페이지 입장시 안 읽은 메시지의 첫번째 인덱스를 받아오는 API 호출해서 채널 아이템에 표시해주는 건 구현 안했음**