### PR TITLE
[CLIENT] 채팅 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,7 @@ import SignUp from '@pages/SignUp';
 import UnAuthorizedLayer from '@pages/UnAuthorizedLayer';
 import UnknownError from '@pages/UnknownError';
 import communitiesLoader from '@routes/communitiesLoader';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import {
   RouterProvider,
   Route,
@@ -27,6 +27,22 @@ import {
 
 import queryClient from './queryClient';
 
+const HomeErrorElement = () => {
+  const errorCount = useRef(1);
+  const maxErrorCount = 3;
+
+  useEffect(() => {
+    errorCount.current += 1;
+  });
+
+  if (errorCount.current >= maxErrorCount) {
+    errorCount.current = 1;
+    return <Navigate to="/unknown-error" />;
+  }
+
+  return <Navigate to="/" />;
+};
+
 const router = createBrowserRouter(
   createRoutesFromElements(
     <Route>
@@ -35,7 +51,7 @@ const router = createBrowserRouter(
         <Route
           element={<Home />}
           loader={communitiesLoader(queryClient)}
-          errorElement={<Navigate to="/" />}
+          errorElement={<HomeErrorElement />}
         >
           <Route path="dms" element={<DM />}>
             <Route index element={<Friends />} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,8 @@ import SignUp from '@pages/SignUp';
 import UnAuthorizedLayer from '@pages/UnAuthorizedLayer';
 import UnknownError from '@pages/UnknownError';
 import communitiesLoader from '@routes/communitiesLoader';
-import React, { useEffect, useRef } from 'react';
+import HomeErrorElement from '@routes/HomeErrorElement';
+import React from 'react';
 import {
   RouterProvider,
   Route,
@@ -26,22 +27,6 @@ import {
 } from 'react-router-dom';
 
 import queryClient from './queryClient';
-
-const HomeErrorElement = () => {
-  const errorCount = useRef(1);
-  const maxErrorCount = 3;
-
-  useEffect(() => {
-    errorCount.current += 1;
-  });
-
-  if (errorCount.current >= maxErrorCount) {
-    errorCount.current = 1;
-    return <Navigate to="/unknown-error" />;
-  }
-
-  return <Navigate to="/" />;
-};
 
 const router = createBrowserRouter(
   createRoutesFromElements(

--- a/client/src/apis/chat.ts
+++ b/client/src/apis/chat.ts
@@ -6,7 +6,7 @@ import { tokenAxios } from '@utils/axios';
 export type ChatType = 'TEXT' | 'IMAGE' | 'SYSTEM';
 
 export interface Chat {
-  id: string;
+  id: number;
   type: ChatType;
   content: string;
   senderId: string;

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -16,6 +16,7 @@ interface Props extends ComponentPropsWithoutRef<'textarea'> {
   initialValue?: string;
   handleCancelEdit?: () => void;
   handleSubmitChat?: (content: string, e: FormEvent) => void;
+  clear?: boolean;
 }
 
 const ChatForm: FC<Props> = ({
@@ -24,6 +25,7 @@ const ChatForm: FC<Props> = ({
   handleSubmitChat,
   handleCancelEdit,
   className,
+  clear = false,
   ...restProps
 }) => {
   const { roomId } = useParams();
@@ -36,7 +38,9 @@ const ChatForm: FC<Props> = ({
    * 채널 입장마다 value 상태값을 초기화합니다.
    **/
   useEffect(() => {
-    setValue('');
+    if (clear) {
+      setValue('');
+    }
   }, [roomId]);
 
   useEffect(() => {
@@ -94,10 +98,11 @@ const ChatForm: FC<Props> = ({
         placeholder="내용을 입력해주세요."
         {...restProps}
         onKeyDown={handleKeyDown}
-        ref={textareaRef}
         value={value}
+        ref={textareaRef}
         onChange={onChange}
       />
+
       <div className="relative h-[30px] shrink-0">
         {editMode && (
           <button

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -4,13 +4,12 @@ import type {
   FormEvent,
   FormEventHandler,
   KeyboardEventHandler,
-  RefObject,
 } from 'react';
 
 import { PaperAirplaneIcon, BackspaceIcon } from '@heroicons/react/24/solid';
 import useInput from '@hooks/useInput';
 import { resizeElementByScrollHeight } from '@utils/dom';
-import React, { forwardRef, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
 interface Props extends ComponentPropsWithRef<'textarea'> {
@@ -21,120 +20,113 @@ interface Props extends ComponentPropsWithRef<'textarea'> {
   clear?: boolean;
 }
 
-const ChatForm: FC<Props> = forwardRef(
-  (
-    {
-      editMode = false,
-      initialValue = '',
-      handleSubmitChat,
-      handleCancelEdit,
-      className,
-      clear = false,
-      ...restProps
-    },
-    ref,
-  ) => {
-    const { roomId } = useParams();
-    const [value, onChange, isDirty, setValue] = useInput(initialValue);
-    const submitButtonRef = useRef<HTMLButtonElement>(null);
-    const textareaRef = ref as RefObject<HTMLTextAreaElement> | null;
+const ChatForm: FC<Props> = ({
+  editMode = false,
+  initialValue = '',
+  handleSubmitChat,
+  handleCancelEdit,
+  className,
+  clear = false,
+  ...restProps
+}) => {
+  const { roomId } = useParams();
+  const [value, onChange, isDirty, setValue] = useInput(initialValue);
+  const submitButtonRef = useRef<HTMLButtonElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-    /**
-     * 다른 채널로 이동시, value 상태값이 유지되며 채팅 폼이 미리 입력되어 있는 현상을 방지하기 위해
-     * 채널 입장마다 value 상태값을 초기화합니다.
-     **/
-    useEffect(() => {
-      if (clear) {
-        setValue('');
-      }
-      resizeElementByScrollHeight(textareaRef?.current);
-    }, [roomId]);
+  /**
+   * 다른 채널로 이동시, value 상태값이 유지되며 채팅 폼이 미리 입력되어 있는 현상을 방지하기 위해
+   * 채널 입장마다 value 상태값을 초기화합니다.
+   **/
+  useEffect(() => {
+    if (clear) {
+      setValue('');
+    }
+    resizeElementByScrollHeight(textareaRef?.current);
+  }, [roomId]);
 
-    useEffect(() => {
-      if (!textareaRef?.current) return undefined;
+  useEffect(() => {
+    if (!textareaRef?.current) return undefined;
 
-      const textarea = textareaRef.current;
+    const textarea = textareaRef.current;
 
-      const handleChangeInput = () => {
-        resizeElementByScrollHeight(textarea);
-      };
+    const handleChangeInput = () => {
+      resizeElementByScrollHeight(textarea);
+    };
 
-      textarea.focus();
-      textarea.addEventListener('input', handleChangeInput);
+    textarea.focus();
+    textarea.addEventListener('input', handleChangeInput);
 
-      return () => textarea.removeEventListener('input', handleChangeInput);
-    }, []);
+    return () => textarea.removeEventListener('input', handleChangeInput);
+  }, []);
 
-    const handleSubmitForm: FormEventHandler<HTMLFormElement> = (e) => {
+  const handleSubmitForm: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    if (!value.trim() || !isDirty) return;
+
+    handleSubmitChat?.(value, e);
+    setValue(initialValue);
+  };
+
+  const handleCancelForm = () => {
+    handleCancelEdit?.();
+  };
+
+  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+    if (e.nativeEvent.isComposing) return;
+
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (!value.trim() || !isDirty) return;
+      submitButtonRef.current?.click();
+      return;
+    }
 
-      handleSubmitChat?.(value, e);
-      setValue(initialValue);
-    };
+    if (editMode && e.key === 'Escape') {
+      handleCancelForm();
+    }
+  };
 
-    const handleCancelForm = () => {
-      handleCancelEdit?.();
-    };
-
-    const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
-      if (e.nativeEvent.isComposing) return;
-
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        submitButtonRef.current?.click();
-        return;
-      }
-
-      if (editMode && e.key === 'Escape') {
-        handleCancelForm();
-      }
-    };
-
-    return (
-      <form
-        className={`flex flex-col p-2 bg-offWhite relative border border-line text-line focus-within:text-indigo focus-within:border-indigo rounded-2xl 
+  return (
+    <form
+      className={`flex flex-col p-2 bg-offWhite relative border border-line text-line focus-within:text-indigo focus-within:border-indigo rounded-2xl 
       [&_button>svg]:fill-line [&:focus-within_.chat-submit-button>svg]:fill-indigo [&_.chat-submit-button:disabled>svg]:fill-line [&:focus-within_.chat-cancel-button>svg]:fill-error ${className}`}
-        onSubmit={handleSubmitForm}
-      >
-        <textarea
-          rows={1}
-          className={`max-h-[120px] grow border-0 p-3 w-full resize-none outline-0 border border-placeholder focus:border-indigo rounded-xl p-3`}
-          placeholder="내용을 입력해주세요."
-          spellCheck={false}
-          {...restProps}
-          onKeyDown={handleKeyDown}
-          value={value}
-          ref={ref}
-          onChange={onChange}
-        />
+      onSubmit={handleSubmitForm}
+    >
+      <textarea
+        rows={1}
+        className={`max-h-[120px] grow border-0 p-3 w-full resize-none outline-0 border border-placeholder focus:border-indigo rounded-xl p-3`}
+        placeholder="내용을 입력해주세요."
+        spellCheck={false}
+        {...restProps}
+        onKeyDown={handleKeyDown}
+        value={value}
+        ref={textareaRef}
+        onChange={onChange}
+      />
 
-        <div className="relative h-[30px] shrink-0">
-          {editMode && (
-            <button
-              type="button"
-              className="chat-cancel-button absolute right-12 h-full [&:hover>svg]:fill-error"
-              onClick={handleCancelForm}
-            >
-              <span className="sr-only">채팅 편집 취소 버튼</span>
-              <BackspaceIcon className="w-6 h-6" />
-            </button>
-          )}
-
+      <div className="relative h-[30px] shrink-0">
+        {editMode && (
           <button
-            className="chat-submit-button absolute right-3 h-full [&:hover>svg]:fill-indigo "
-            ref={submitButtonRef}
-            disabled={!isDirty}
+            type="button"
+            className="chat-cancel-button absolute right-12 h-full [&:hover>svg]:fill-error"
+            onClick={handleCancelForm}
           >
-            <span className="sr-only">채팅 입력 버튼</span>
-            <PaperAirplaneIcon className="w-6 h-6" />
+            <span className="sr-only">채팅 편집 취소 버튼</span>
+            <BackspaceIcon className="w-6 h-6" />
           </button>
-        </div>
-      </form>
-    );
-  },
-);
+        )}
 
-ChatForm.displayName = 'ChatForm';
+        <button
+          className="chat-submit-button absolute right-3 h-full [&:hover>svg]:fill-indigo "
+          ref={submitButtonRef}
+          disabled={!isDirty}
+        >
+          <span className="sr-only">채팅 입력 버튼</span>
+          <PaperAirplaneIcon className="w-6 h-6" />
+        </button>
+      </div>
+    </form>
+  );
+};
 
 export default ChatForm;

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -8,6 +8,7 @@ import type {
 
 import { PaperAirplaneIcon, BackspaceIcon } from '@heroicons/react/24/solid';
 import useInput from '@hooks/useInput';
+import { resizeElementByScrollHeight } from '@utils/dom';
 import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -41,6 +42,7 @@ const ChatForm: FC<Props> = ({
     if (clear) {
       setValue('');
     }
+    resizeElementByScrollHeight(textareaRef?.current);
   }, [roomId]);
 
   useEffect(() => {
@@ -49,10 +51,7 @@ const ChatForm: FC<Props> = ({
     const textarea = textareaRef.current;
 
     const handleChangeInput = () => {
-      if (textarea) {
-        textarea.style.height = 'auto';
-        textarea.style.height = `${textarea.scrollHeight}px`;
-      }
+      resizeElementByScrollHeight(textarea);
     };
 
     textarea.addEventListener('input', handleChangeInput);

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -94,7 +94,7 @@ const ChatForm: FC<Props> = ({
     >
       <textarea
         rows={1}
-        className={`grow border-0 p-3 w-full resize-none outline-0 border border-placeholder focus:border-indigo rounded-xl p-3`}
+        className={`max-h-[120px] grow border-0 p-3 w-full resize-none outline-0 border border-placeholder focus:border-indigo rounded-xl p-3`}
         placeholder="내용을 입력해주세요."
         {...restProps}
         onKeyDown={handleKeyDown}

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -1,18 +1,19 @@
 import type {
-  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
   FC,
   FormEvent,
   FormEventHandler,
   KeyboardEventHandler,
+  RefObject,
 } from 'react';
 
 import { PaperAirplaneIcon, BackspaceIcon } from '@heroicons/react/24/solid';
 import useInput from '@hooks/useInput';
 import { resizeElementByScrollHeight } from '@utils/dom';
-import React, { useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 
-interface Props extends ComponentPropsWithoutRef<'textarea'> {
+interface Props extends ComponentPropsWithRef<'textarea'> {
   editMode?: boolean;
   initialValue?: string;
   handleCancelEdit?: () => void;
@@ -20,19 +21,23 @@ interface Props extends ComponentPropsWithoutRef<'textarea'> {
   clear?: boolean;
 }
 
-const ChatForm: FC<Props> = ({
-  editMode = false,
-  initialValue = '',
-  handleSubmitChat,
-  handleCancelEdit,
-  className,
-  clear = false,
-  ...restProps
-}) => {
-  const { roomId } = useParams();
-  const [value, onChange, isDirty, setValue] = useInput(initialValue);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const submitButtonRef = useRef<HTMLButtonElement>(null);
+const ChatForm: FC<Props> = forwardRef(
+  (
+    {
+      editMode = false,
+      initialValue = '',
+      handleSubmitChat,
+      handleCancelEdit,
+      className,
+      clear = false,
+      ...restProps
+    },
+    ref,
+  ) => {
+    const { roomId } = useParams();
+    const [value, onChange, isDirty, setValue] = useInput(initialValue);
+    const submitButtonRef = useRef<HTMLButtonElement>(null);
+    const textareaRef = ref as RefObject<HTMLTextAreaElement> | null;
 
   /**
    * 다른 채널로 이동시, value 상태값이 유지되며 채팅 폼이 미리 입력되어 있는 현상을 방지하기 위해
@@ -115,17 +120,20 @@ const ChatForm: FC<Props> = ({
           </button>
         )}
 
-        <button
-          className="chat-submit-button absolute right-3 h-full [&:hover>svg]:fill-indigo "
-          ref={submitButtonRef}
-          disabled={!isDirty}
-        >
-          <span className="sr-only">채팅 입력 버튼</span>
-          <PaperAirplaneIcon className="w-6 h-6" />
-        </button>
-      </div>
-    </form>
-  );
-};
+          <button
+            className="chat-submit-button absolute right-3 h-full [&:hover>svg]:fill-indigo "
+            ref={submitButtonRef}
+            disabled={!isDirty}
+          >
+            <span className="sr-only">채팅 입력 버튼</span>
+            <PaperAirplaneIcon className="w-6 h-6" />
+          </button>
+        </div>
+      </form>
+    );
+  },
+);
+
+ChatForm.displayName = 'ChatForm';
 
 export default ChatForm;

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -89,18 +89,19 @@ const ChatForm: FC<Props> = ({
     <form
       className={`flex flex-col p-2 bg-offWhite relative border border-line text-line focus-within:text-indigo focus-within:border-indigo rounded-2xl 
       [&_button>svg]:fill-line [&:focus-within_.chat-submit-button>svg]:fill-indigo [&_.chat-submit-button:disabled>svg]:fill-line [&:focus-within_.chat-cancel-button>svg]:fill-error ${className}`}
-      onSubmit={handleSubmitForm}
-    >
-      <textarea
-        rows={1}
-        className={`max-h-[120px] grow border-0 p-3 w-full resize-none outline-0 border border-placeholder focus:border-indigo rounded-xl p-3`}
-        placeholder="내용을 입력해주세요."
-        {...restProps}
-        onKeyDown={handleKeyDown}
-        value={value}
-        ref={textareaRef}
-        onChange={onChange}
-      />
+        onSubmit={handleSubmitForm}
+      >
+        <textarea
+          rows={1}
+          className={`max-h-[120px] grow border-0 p-3 w-full resize-none outline-0 border border-placeholder focus:border-indigo rounded-xl p-3`}
+          placeholder="내용을 입력해주세요."
+          spellCheck={false}
+          {...restProps}
+          onKeyDown={handleKeyDown}
+          value={value}
+          ref={ref}
+          onChange={onChange}
+        />
 
       <div className="relative h-[30px] shrink-0">
         {editMode && (

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -39,60 +39,61 @@ const ChatForm: FC<Props> = forwardRef(
     const submitButtonRef = useRef<HTMLButtonElement>(null);
     const textareaRef = ref as RefObject<HTMLTextAreaElement> | null;
 
-  /**
-   * 다른 채널로 이동시, value 상태값이 유지되며 채팅 폼이 미리 입력되어 있는 현상을 방지하기 위해
-   * 채널 입장마다 value 상태값을 초기화합니다.
-   **/
-  useEffect(() => {
-    if (clear) {
-      setValue('');
-    }
-    resizeElementByScrollHeight(textareaRef?.current);
-  }, [roomId]);
+    /**
+     * 다른 채널로 이동시, value 상태값이 유지되며 채팅 폼이 미리 입력되어 있는 현상을 방지하기 위해
+     * 채널 입장마다 value 상태값을 초기화합니다.
+     **/
+    useEffect(() => {
+      if (clear) {
+        setValue('');
+      }
+      resizeElementByScrollHeight(textareaRef?.current);
+    }, [roomId]);
 
-  useEffect(() => {
-    if (!textareaRef.current) return undefined;
+    useEffect(() => {
+      if (!textareaRef?.current) return undefined;
 
-    const textarea = textareaRef.current;
+      const textarea = textareaRef.current;
 
-    const handleChangeInput = () => {
-      resizeElementByScrollHeight(textarea);
+      const handleChangeInput = () => {
+        resizeElementByScrollHeight(textarea);
+      };
+
+      textarea.focus();
+      textarea.addEventListener('input', handleChangeInput);
+
+      return () => textarea.removeEventListener('input', handleChangeInput);
+    }, []);
+
+    const handleSubmitForm: FormEventHandler<HTMLFormElement> = (e) => {
+      e.preventDefault();
+      if (!value.trim() || !isDirty) return;
+
+      handleSubmitChat?.(value, e);
+      setValue(initialValue);
     };
 
-    textarea.addEventListener('input', handleChangeInput);
+    const handleCancelForm = () => {
+      handleCancelEdit?.();
+    };
 
-    return () => textarea.removeEventListener('input', handleChangeInput);
-  }, []);
+    const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+      if (e.nativeEvent.isComposing) return;
 
-  const handleSubmitForm: FormEventHandler<HTMLFormElement> = (e) => {
-    e.preventDefault();
-    if (!value.trim() || !isDirty) return;
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        submitButtonRef.current?.click();
+        return;
+      }
 
-    handleSubmitChat?.(value, e);
-    setValue(initialValue);
-  };
+      if (editMode && e.key === 'Escape') {
+        handleCancelForm();
+      }
+    };
 
-  const handleCancelForm = () => {
-    handleCancelEdit?.();
-  };
-
-  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
-    if (e.nativeEvent.isComposing) return;
-
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      submitButtonRef.current?.click();
-      return;
-    }
-
-    if (editMode && e.key === 'Escape') {
-      handleCancelForm();
-    }
-  };
-
-  return (
-    <form
-      className={`flex flex-col p-2 bg-offWhite relative border border-line text-line focus-within:text-indigo focus-within:border-indigo rounded-2xl 
+    return (
+      <form
+        className={`flex flex-col p-2 bg-offWhite relative border border-line text-line focus-within:text-indigo focus-within:border-indigo rounded-2xl 
       [&_button>svg]:fill-line [&:focus-within_.chat-submit-button>svg]:fill-indigo [&_.chat-submit-button:disabled>svg]:fill-line [&:focus-within_.chat-cancel-button>svg]:fill-error ${className}`}
         onSubmit={handleSubmitForm}
       >
@@ -108,17 +109,17 @@ const ChatForm: FC<Props> = forwardRef(
           onChange={onChange}
         />
 
-      <div className="relative h-[30px] shrink-0">
-        {editMode && (
-          <button
-            type="button"
-            className="chat-cancel-button absolute right-12 h-full [&:hover>svg]:fill-error"
-            onClick={handleCancelForm}
-          >
-            <span className="sr-only">채팅 편집 취소 버튼</span>
-            <BackspaceIcon className="w-6 h-6" />
-          </button>
-        )}
+        <div className="relative h-[30px] shrink-0">
+          {editMode && (
+            <button
+              type="button"
+              className="chat-cancel-button absolute right-12 h-full [&:hover>svg]:fill-error"
+              onClick={handleCancelForm}
+            >
+              <span className="sr-only">채팅 편집 취소 버튼</span>
+              <BackspaceIcon className="w-6 h-6" />
+            </button>
+          )}
 
           <button
             className="chat-submit-button absolute right-3 h-full [&:hover>svg]:fill-indigo "

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -6,6 +6,7 @@ import Avatar from '@components/Avatar';
 import ChatContent from '@components/ChatContent';
 import ChatForm from '@components/ChatForm';
 import ChatActions from '@components/ChatItem/ChatActions';
+import { useMyInfoQueryData } from '@hooks/auth';
 import { useSetChatsQueryData } from '@hooks/chat';
 import useHover from '@hooks/useHover';
 import { useSocketStore } from '@stores/socketStore';
@@ -110,12 +111,13 @@ interface Props extends ComponentPropsWithoutRef<'li'> {
 const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
   const chatContentRef = useRef<HTMLDivElement>(null);
   const [isEditing, setIsEditing] = useState(false);
+  const myInfo = useMyInfoQueryData() as User;
   const { roomId, communityId } = useParams() as {
     roomId: string;
     communityId: string;
   };
   const socket = useSocketStore((state) => state.sockets[communityId]);
-  const { content, written, id } = chat;
+  const { content, written, id, senderId } = chat;
   const { isDeleted, isFailedToSendChat } = getChatStatus(chat);
   const { isHover, ...hoverHandlers } = useHover(false);
   const {
@@ -126,6 +128,7 @@ const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
   } = useSetChatsQueryData();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isPending = written === -1;
+  const isMine = myInfo._id === senderId;
 
   const opacityClassnames = cn({
     'opacity-40': isPending || isFailedToSendChat,
@@ -243,7 +246,7 @@ const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
             {!isEditing && !isPending && isHover && (
               <ChatActions.Container className="bg-background">
                 <ChatActions.Copy onClick={handleClickCopyButton} />
-                <ChatActions.Edit onClick={handleClickEditButton} />
+                {isMine && <ChatActions.Edit onClick={handleClickEditButton} />}
                 <ChatActions.Remove />
               </ChatActions.Container>
             )}

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -188,19 +188,20 @@ const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
       },
     );
 
-    const fail = false;
-
-    setTimeout(() => {
-      if (fail) {
-        updateEditChatToFailedChat({ id, channelId: roomId, content });
-        toast.error('채팅 수정에 실패했습니다.');
-      } else {
-        updateEditChatToWrittenChat({
-          updatedChat: { ...chat, ...editedChatInfo },
-          channelId: roomId,
-        });
-      }
-    }, 1000);
+    // 테스트용
+    // const fail = true;
+    //
+    // setTimeout(() => {
+    //   if (fail) {
+    //     updateEditChatToFailedChat({ id, channelId: roomId, content });
+    //     toast.error('채팅 수정에 실패했습니다.');
+    //   } else {
+    //     updateEditChatToWrittenChat({
+    //       updatedChat: { ...chat, ...editedChatInfo },
+    //       channelId: roomId,
+    //     });
+    //   }
+    // }, 1000);
   };
 
   return (

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -207,6 +207,10 @@ const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
     // }, 1000);
   };
 
+  const handleCancelChatEditForm = () => {
+    setIsEditing(false);
+  };
+
   return (
     chat && (
       <li className={`relative ${className}`} {...hoverHandlers}>
@@ -236,6 +240,7 @@ const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
                   initialValue={content}
                   ref={textareaRef}
                   handleSubmitChat={handleSubmitChatEditForm}
+                  handleCancelEdit={handleCancelChatEditForm}
                 />
               ) : (
                 <ChatContent content={content} />

--- a/client/src/components/ChatItem/index.tsx
+++ b/client/src/components/ChatItem/index.tsx
@@ -126,7 +126,6 @@ const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
     updateEditChatToWrittenChat,
     updateEditChatToFailedChat,
   } = useSetChatsQueryData();
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const isPending = written === -1;
   const isMine = myInfo._id === senderId;
 
@@ -238,7 +237,6 @@ const ChatItem: FC<Props> = ({ className = '', chat, user = deletedUser }) => {
                 <ChatForm
                   editMode
                   initialValue={content}
-                  ref={textareaRef}
                   handleSubmitChat={handleSubmitChatEditForm}
                   handleCancelEdit={handleCancelChatEditForm}
                 />

--- a/client/src/components/GnbItemContainer/index.tsx
+++ b/client/src/components/GnbItemContainer/index.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode, FC } from 'react';
 
+import useHover from '@hooks/useHover';
 import cn from 'classnames';
-import React, { useState, memo, useCallback } from 'react';
+import React, { memo } from 'react';
 
 interface Props {
   children: ReactNode;
@@ -16,16 +17,13 @@ const GnbItemContainer: FC<Props> = ({
   disableLeftFillBar = false,
   isActive = false,
 }) => {
-  const [isItemHover, setIsItemHover] = useState(false);
+  const { isHover, ...hoverHandlers } = useHover(false);
   const leftFillBarClassnames = disableLeftFillBar
     ? ''
     : cn({
-        'bg-primary-light': isItemHover,
+        'bg-primary-light': isHover,
         'bg-primary-dark': isActive,
       });
-
-  const handleMouseEnterOnItem = useCallback(() => setIsItemHover(true), []);
-  const handleMouseLeaveFromItem = useCallback(() => setIsItemHover(false), []);
 
   return (
     <div className="relative w-full mb-[10px]">
@@ -34,11 +32,7 @@ const GnbItemContainer: FC<Props> = ({
       ></div>
       <div className="flex justify-center">
         {/* Item 영역 */}
-        <div
-          className="max-w-min"
-          onMouseEnter={handleMouseEnterOnItem}
-          onMouseLeave={handleMouseLeaveFromItem}
-        >
+        <div className="max-w-min" {...hoverHandlers}>
           {children}
         </div>
       </div>

--- a/client/src/components/UserActionBox/index.tsx
+++ b/client/src/components/UserActionBox/index.tsx
@@ -6,6 +6,7 @@ import defaultErrorHandler from '@errors/defaultErrorHandler';
 import { PencilIcon } from '@heroicons/react/24/solid';
 import { useSignOutMutation } from '@hooks/auth';
 import { useRootStore } from '@stores/rootStore';
+import { useSocketStore } from '@stores/socketStore';
 import { useTokenStore } from '@stores/tokenStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { dateStringToKRLocaleDateString } from '@utils/date';
@@ -21,8 +22,10 @@ const UserActionBox: FC<Props> = ({
   user: { status, nickname, profileUrl, createdAt },
 }) => {
   const closeCommonModal = useRootStore((state) => state.closeCommonModal);
-  const navigate = useNavigate();
   const setAccessToken = useTokenStore((state) => state.setAccessToken);
+  const sockets = useSocketStore((state) => state.sockets);
+  const setSockets = useSocketStore((state) => state.setSockets);
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const signOutMutation = useSignOutMutation({
     onSuccess: () => {
@@ -30,6 +33,10 @@ const UserActionBox: FC<Props> = ({
       closeCommonModal();
       queryClient.clear();
       toast.success('성공적으로 로그아웃하였습니다!');
+      Object.values(sockets).forEach((socket) => {
+        socket.disconnect();
+      });
+      setSockets({});
       navigate('/sign-in', {
         state: { alreadyTriedReissueToken: true },
         replace: true,

--- a/client/src/components/UserActionBox/index.tsx
+++ b/client/src/components/UserActionBox/index.tsx
@@ -4,9 +4,10 @@ import type { FC } from 'react';
 import Avatar from '@components/Avatar';
 import defaultErrorHandler from '@errors/defaultErrorHandler';
 import { PencilIcon } from '@heroicons/react/24/solid';
-import { useSetMyInfoQueryData, useSignOutMutation } from '@hooks/auth';
+import { useSignOutMutation } from '@hooks/auth';
 import { useRootStore } from '@stores/rootStore';
 import { useTokenStore } from '@stores/tokenStore';
+import { useQueryClient } from '@tanstack/react-query';
 import { dateStringToKRLocaleDateString } from '@utils/date';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -20,14 +21,14 @@ const UserActionBox: FC<Props> = ({
   user: { status, nickname, profileUrl, createdAt },
 }) => {
   const closeCommonModal = useRootStore((state) => state.closeCommonModal);
-  const { removeMyInfoQueryData } = useSetMyInfoQueryData();
   const navigate = useNavigate();
   const setAccessToken = useTokenStore((state) => state.setAccessToken);
+  const queryClient = useQueryClient();
   const signOutMutation = useSignOutMutation({
     onSuccess: () => {
       setAccessToken(null);
       closeCommonModal();
-      removeMyInfoQueryData();
+      queryClient.clear();
       toast.success('성공적으로 로그아웃하였습니다!');
       navigate('/sign-in', {
         state: { alreadyTriedReissueToken: true },

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -40,12 +40,11 @@ type UpdateChatToWrittenChat = ({
   realChatId,
 }: Pick<Chat, 'id'> & { channelId: string; realChatId: number }) => void;
 
-type UpdateChatQueryDataToFailedChat = ({
+type UpdateChatToFailedChat = ({
   id,
   channelId,
 }: Pick<Chat, 'id'> & { channelId: string }) => void;
 
-type UpdateChatToFailedChat = UpdateChatToWrittenChat;
 type RemoveChatQueryData = ({
   id,
   channelId,

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -139,7 +139,7 @@ const SocketLayer = () => {
     // });
     // handleReceiveEditChat({
     //   updatedChat: {
-    //     id: 59,
+    //     id: Math.floor(Math.random() * 5) + 55,
     //     content: Math.random().toString(),
     //     createdAt: '',
     //     deletedAt: '',
@@ -148,7 +148,7 @@ const SocketLayer = () => {
     //     senderId: '',
     //     written: undefined,
     //   },
-    //   channelId: '039f672f-1cc2-4c82-a2f3-0e90999b83d1',
+    //   channelId: 'c84ce979-7e14-497a-8384-774318468cf2',
     // });
     // }, 3000);
 

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -78,6 +78,7 @@ const SocketLayer = () => {
   useEffect(() => {
     if (firstEffect.current) return undefined;
 
+    // TODO: 채팅 받을 때의 명세가 달라질 것 같으니 수정 준비하세요~
     const handleReceiveChat: ReceiveChatHandler = ({
       // communityId,
       id,

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -1,6 +1,7 @@
 import type {
   ReceiveChatHandler,
   InvitedToChannelHandler,
+  ReceiveEditChatHandler,
 } from '@/socketEvents';
 import type { CommunitySummaries } from '@apis/community';
 import type { Sockets } from '@stores/socketStore';
@@ -34,9 +35,9 @@ const SocketLayer = () => {
 
   const chatScrollbar = useRootStore((state) => state.chatScrollbar);
 
-  const { addChatsQueryData } = useSetChatsQueryData();
   const { addChannelQueryData, updateLastReadInChannelQueryData } =
     useSetChannelQueryData();
+  const { addChatsQueryData, updateChatQueryData } = useSetChatsQueryData();
 
   useEffect(() => {
     const opts = {
@@ -105,6 +106,13 @@ const SocketLayer = () => {
         updateLastReadInChannelQueryData(communityIds[0], channelId, true);
     };
 
+    const handleReceiveEditChat: ReceiveEditChatHandler = ({
+      updatedChat,
+      channelId,
+    }) => {
+      updateChatQueryData({ updatedChat, channelId });
+    };
+
     const handleInvitedToChannel: InvitedToChannelHandler = ({
       communityId,
       ...joinedChannel
@@ -113,21 +121,34 @@ const SocketLayer = () => {
     };
 
     // const interval = setInterval(() => {
-    //   handleReceiveChat({
-    //     id: faker.datatype.uuid(),
-    //     channelId: 'ce616c1f-6dee-48de-9f93-9c757ce8bfc9',
-    //     time: new Date(),
-    //     message: '두번째 채널',
-    //     user_id: '190eb95f-d854-4082-9847-7d66da0c1238',
-    //   });
+    // handleReceiveChat({
+    //   id: Date.now(),
+    //   channelId: 'ce616c1f-6dee-48de-9f93-9c757ce8bfc9',
+    //   time: new Date(),
+    //   message: '두번째 채널',
+    //   user_id: '190eb95f-d854-4082-9847-7d66da0c1238',
+    // });
     //
-    //   handleReceiveChat({
-    //     id: faker.datatype.uuid(),
-    //     channelId: '28f5bb16-e236-4704-8f02-84fbcd89130f',
-    //     time: new Date(),
-    //     message: '첫번째 채널',
-    //     user_id: '1b1260f9-04bf-4e91-9728-c979b0f9e4ed',
-    //   });
+    // handleReceiveChat({
+    //   id: Date.now(),
+    //   channelId: '28f5bb16-e236-4704-8f02-84fbcd89130f',
+    //   time: new Date(),
+    //   message: '첫번째 채널',
+    //   user_id: '1b1260f9-04bf-4e91-9728-c979b0f9e4ed',
+    // });
+    // handleReceiveEditChat({
+    //   updatedChat: {
+    //     id: 59,
+    //     content: Math.random().toString(),
+    //     createdAt: '',
+    //     deletedAt: '',
+    //     type: 'TEXT',
+    //     updatedAt: new Date().toISOString(),
+    //     senderId: '',
+    //     written: undefined,
+    //   },
+    //   channelId: '039f672f-1cc2-4c82-a2f3-0e90999b83d1',
+    // });
     // }, 3000);
 
     // 이벤트 on
@@ -140,6 +161,7 @@ const SocketLayer = () => {
         }
       });
 
+      socket.on(SOCKET_EVENTS.RECEIVE_EDIT_CHAT, handleReceiveEditChat);
       socket.on(SOCKET_EVENTS.INVITED_TO_CHANNEL, handleInvitedToChannel);
     });
 

--- a/client/src/mocks/data/chats.js
+++ b/client/src/mocks/data/chats.js
@@ -2,14 +2,40 @@ import { faker } from '@faker-js/faker';
 
 import { users } from './users';
 
+let id = 0;
+
 export const createMockChat = () => ({
-  id: faker.datatype.uuid(),
+  id: id++,
   type: 'TEXT',
   content: faker.lorem.sentences(),
-  senderId: users[0]._id,
+  senderId: users[Math.floor(Math.random() * users.length)]._id,
   updatedAt: '',
   createdAt: new Date().toISOString(),
   deletedAt: '',
 });
 
-export const chats = [...Array(20)].map(createMockChat);
+const chatsLength = 60;
+const chatCountPerPage = 20;
+const chats = [...Array(chatsLength)].map(createMockChat);
+const totalPageCount = Math.ceil(chatsLength / chatCountPerPage) - 1;
+
+/**
+ * @param cursor {number}
+ */
+const getChats = (cursor) => {
+  if (cursor === -1) {
+    return [];
+  }
+
+  const start = cursor * chatCountPerPage;
+  const end = start + chatCountPerPage;
+
+  return chats.slice(start, end);
+};
+
+export default {
+  chats,
+  chatCountPerPage,
+  totalPageCount,
+  getChats,
+};

--- a/client/src/mocks/handlers/Chat.js
+++ b/client/src/mocks/handlers/Chat.js
@@ -2,40 +2,40 @@ import endPoint from '@constants/endPoint';
 import { API_URL } from '@constants/url';
 import { rest } from 'msw';
 
-import { createMockChat } from '../data/chats';
+import chatData from '../data/chats';
 import {
   createErrorContext,
   createSuccessContext,
 } from '../utils/createContext';
-
-const MAX_PREVIOUS_PAGE = 2;
+import { colorLog } from '../utils/logging';
 
 const getChannelEndPoint = API_URL + endPoint.getChats(':channelId');
 const GetChats = rest.get(getChannelEndPoint, (req, res, ctx) => {
-  // const { channelId } = req.params;
-  const prev = Number(req.url.searchParams.get('prev'));
-  // const nextCursor = req.url.searchParams.get('next');
-
+  let cursor = Number(req.url.searchParams.get('prev'));
   const ERROR = false;
 
   // prevCursor가 undefined이거나 0이면 그대로 undefined를 반환한다.
   // prevCursor가 -1이면 첫 요청이라는 뜻이므로 최대 페이지 개수를 반환한다.
   // 그렇지 않으면 prevCursor를 1 줄여 보낸다.
-  const newPrevCursor =
-    isNaN(prev) || prev === 0
-      ? undefined
-      : prev === -1
-      ? MAX_PREVIOUS_PAGE
-      : prev - 1;
+  let prevCursor;
 
-  console.log(newPrevCursor);
+  if (cursor === 0) {
+    prevCursor = undefined;
+  } else if (cursor === -1) {
+    cursor = chatData.totalPageCount;
+    prevCursor = cursor - 1;
+  } else {
+    prevCursor = cursor - 1;
+  }
+
+  const chat = cursor >= 0 ? chatData.getChats(cursor) : [];
+
+  colorLog(`Mock Chats Fetch: ${cursor}페이지를 불러옵니다.`);
   const errorResponse = res(...createErrorContext(ctx));
   const successResponse = res(
-    ...createSuccessContext(ctx, 200, 1000, {
-      prev: newPrevCursor,
-      chat: Number.isInteger(newPrevCursor)
-        ? [...Array(10)].map(createMockChat)
-        : [],
+    ...createSuccessContext(ctx, 200, 500, {
+      prev: prevCursor,
+      chat,
     }),
   );
 

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -3,7 +3,6 @@ import type { User } from '@apis/user';
 import ChatForm from '@components/ChatForm';
 import ChatList from '@components/ChatList';
 import Spinner from '@components/Spinner';
-import { faker } from '@faker-js/faker';
 import { useMyInfoQueryData } from '@hooks/auth';
 import {
   useChannelWithUsersMapQuery,
@@ -61,7 +60,7 @@ const Channel = () => {
   const socket = useSocketStore((state) => state.sockets[communityId]);
 
   const handleSubmitChat = (content: string) => {
-    const id = faker.datatype.uuid();
+    const id = Date.now();
     const createdAt = new Date();
     const newChat = { id, content, createdAt, senderId: myInfo._id };
 
@@ -81,9 +80,15 @@ const Channel = () => {
         ...newChat,
         channelId: roomId,
       }),
-      ({ written }: { written: boolean }) => {
-        if (written) {
-          updateChatToWrittenChat({ id, channelId: roomId });
+      (
+        response: { written: true; realChatId: number } | { written: false },
+      ) => {
+        if (response.written) {
+          updateChatToWrittenChat({
+            id,
+            realChatId: response.realChatId,
+            channelId: roomId,
+          });
           return;
         }
 

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -164,6 +164,7 @@ const Channel = () => {
           <ChatForm
             className="max-h-[20%] w-[95%] grow shrink-0 mx-auto mt-6"
             handleSubmitChat={handleSubmitChat}
+            clear
           />
         </div>
         <div className="flex grow w-80 h-full border-l border-line">

--- a/client/src/routes/HomeErrorElement.tsx
+++ b/client/src/routes/HomeErrorElement.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+let errorCount = 0;
+const HomeErrorElement = () => {
+  const maxErrorCount = 3;
+
+  errorCount += 1;
+
+  if (errorCount >= maxErrorCount) {
+    errorCount = 0;
+    return <Navigate to="/unknown-error" />;
+  }
+
+  return <Navigate to="/" />;
+};
+
+export default HomeErrorElement;

--- a/client/src/socketEvents/clientIO.ts
+++ b/client/src/socketEvents/clientIO.ts
@@ -1,0 +1,58 @@
+import type { ManagerOptions, Socket, SocketOptions } from 'socket.io-client';
+
+import { SOCKET_URL } from '@constants/url';
+import { io } from 'socket.io-client';
+
+import { joinChannelsPayload, SOCKET_EVENTS } from '@/socketEvents/index';
+
+interface ClientIOConstructor {
+  communityId: string;
+  opts?: Partial<ManagerOptions & SocketOptions> | undefined;
+}
+
+export default class ClientIO {
+  private io: Socket;
+
+  static createOpts({ token }: { token: string }) {
+    return {
+      auth: { token: `Bearer ${token}` },
+    };
+  }
+
+  constructor({ communityId, opts }: ClientIOConstructor) {
+    this.io = io(`${SOCKET_URL}/socket/commu-${communityId}`, opts);
+  }
+
+  on<T extends (...params: unknown[]) => unknown>(
+    eventName: string,
+    handler: T,
+  ) {
+    this.io.on(eventName, handler);
+  }
+
+  off(eventName: string) {
+    this.io.off(eventName);
+  }
+
+  emit<T, C extends (...params: unknown[]) => unknown | undefined>(
+    eventName: string,
+    payload?: T,
+    emitCallback?: C,
+  ) {
+    this.io.emit(eventName, payload, emitCallback);
+  }
+
+  joinChannels(communityIds: string[]) {
+    this.emit(SOCKET_EVENTS.JOIN_CHANNEL, joinChannelsPayload(communityIds));
+  }
+
+  sendChat() {
+    this.emit(SOCKET_EVENTS.SEND_CHAT);
+  }
+
+  editChat() {}
+
+  removeChat() {}
+
+  inviteUsersToChannel() {}
+}

--- a/client/src/socketEvents/index.ts
+++ b/client/src/socketEvents/index.ts
@@ -1,11 +1,14 @@
 import type { JoinedChannel } from '@apis/channel';
+import type { Chat } from '@apis/chat';
 import type { CommunitySummary } from '@apis/community';
 import type { User } from '@apis/user';
 
 export const SOCKET_EVENTS = {
   JOIN_CHANNEL: 'join',
-  SEND_CHAT: 'new-message',
+  SEND_CHAT: 'message',
+  EDIT_CHAT: 'message',
   RECEIVE_CHAT: 'new-message',
+  RECEIVE_EDIT_CHAT: 'modify-message',
   INVALID_TOKEN: 'connect_error',
   INVITE_USERS_TO_CHANNEL: 'invite-users-to-channel',
   INVITED_TO_CHANNEL: 'invited-to-channel',
@@ -16,7 +19,7 @@ export const joinChannelsPayload = (channelIds: string[]) => ({
 });
 
 export interface SendChatPayloadParameter {
-  id: string;
+  id: number;
   channelId: string;
   senderId: string;
   content: string;
@@ -31,6 +34,7 @@ export const sendChatPayload = ({
   createdAt,
 }: SendChatPayloadParameter) => ({
   id,
+  type: 'new',
   channelId,
   user_id: senderId,
   message: content,
@@ -38,7 +42,7 @@ export const sendChatPayload = ({
 });
 
 export interface ReceiveChatPayload {
-  id: string;
+  id: number;
   channelId: string;
   user_id: string;
   message: string;
@@ -52,6 +56,33 @@ export type ReceiveChatHandler = ({
   message,
   time,
 }: ReceiveChatPayload) => void;
+
+export interface EditChatPayloadParameter {
+  id: number;
+  channelId: string;
+  content: string;
+}
+
+export const editChatPayload = ({
+  id,
+  channelId,
+  content,
+}: EditChatPayloadParameter) => ({
+  messageId: id,
+  type: 'modify',
+  channelId,
+  message: content,
+});
+
+export interface ReceiveEditChatHandlerParameter {
+  updatedChat: Chat;
+  channelId: string;
+}
+
+export type ReceiveEditChatHandler = ({
+  updatedChat,
+  channelId,
+}: ReceiveEditChatHandlerParameter) => void;
 
 /* ======================= [ 채널 초대 보내기 ] ====================== */
 export interface InviteUsersToChannelPayloadParameter {

--- a/client/src/utils/dom.ts
+++ b/client/src/utils/dom.ts
@@ -1,0 +1,8 @@
+import type { Nullable } from '@@types/common';
+
+export const resizeElementByScrollHeight = (ref?: Nullable<HTMLElement>) => {
+  if (ref) {
+    ref.style.height = 'auto';
+    ref.style.height = `${ref.scrollHeight}px`;
+  }
+};


### PR DESCRIPTION
## Issues
- #318

<!-- 어떤 이슈와 관련된 PR인지 적어주세요! 이슈와 PR을 연결하려면 반드시 적어야 합니다. -->
<!-- 필요하다면 여러 이슈를 적는 것도 가능할지도? -->
<!-- - #IssueNumber 로 타이핑하면 자동완성되는 문장을 사용해주세요. -->
<!-- 예시) - #1 -->

## 🤷‍♂️ Description
채팅 수정만 하려고 했는데, 도중에 슬랙으로 버그 제보(/dms -> /무한루프)가 와서 그것까지 마저 수정하였습니다.

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 소켓 리팩토링할 때 사용할 ClientIO 클래스 뼈대만 정의
- [X] clear props 추가
- [X] 스크롤바 조절 함수 분리.
- [X] 채팅 mock data, mock api 변경
- [X] realChatId가 필요해서 채팅 보내기에서 written true로 수정해주는 함수 로직 변경
  - 초기에는 `fakeChatId`로 렌더링해주는데, 이후에 수정 및 삭제에서 채팅 아이디를 전달하기 위해서는 `realChatId`가 필요함.
- [X] editChat 관련 커스텀 훅 추가
- [X] 채팅 수정 추가
- [X] `/dms` -> `/` -> `/dms` 무한반복 fix
- [X] 채팅 수정 취소하기



## 📷 Screenshots
 - 채팅 수정 성공
![채팅수정성공](https://user-images.githubusercontent.com/79135734/206878767-7b69ad1d-a4e8-4dc6-b623-497e3293d52c.gif)

- 채팅 수정 실패
![채팅수정실패](https://user-images.githubusercontent.com/79135734/206878773-9d43d508-5282-4447-8779-0f56056db93d.gif)

- 다른 사람의 채팅 수정 반영
![다른사람이 채팅수정](https://user-images.githubusercontent.com/79135734/206878774-591615e6-4eb6-423b-81f1-9f55f1c8c36b.gif)

## 📒 Remarks

  - new Chat은 기본적으로 마지막 페이지에 추가됩니다. 그래서 페이지 탐색이 필요 없습니다.
  - edit Chat은 어떤 채팅이 수정될 지 모르기 때문에, 수정된 채팅이 어떤 페이지에 존재하는지 탐색이 필요합니다. 
  - 채팅이 인덱스번호를 아이디로 가져서 효율적인 탐색 가능
  - 이 탐색 로직을 공통 함수로 분리
  - 채팅 수정 취소는 취소버튼 누르거나 ESC 누르면 취소됩니다.