### PR TITLE
[CLIENT] 에러 페이지

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import Channel from '@pages/Channel';
 import Community from '@pages/Community';
 import DM from '@pages/DM';
 import DMRoom from '@pages/DMRoom';
+import Error from '@pages/Error';
 import Friends from '@pages/Friends';
 import Home from '@pages/Home';
 import NotFound from '@pages/NotFound';
@@ -13,7 +14,6 @@ import Root from '@pages/Root';
 import SignIn from '@pages/SignIn';
 import SignUp from '@pages/SignUp';
 import UnAuthorizedLayer from '@pages/UnAuthorizedLayer';
-import UnknownError from '@pages/UnknownError';
 import communitiesLoader from '@routes/communitiesLoader';
 import HomeErrorElement from '@routes/HomeErrorElement';
 import React from 'react';
@@ -71,7 +71,7 @@ const router = createBrowserRouter(
         <Route path="sign-up" element={<SignUp />} />
       </Route>
       <Route path="/access-denied" element={<AccessDenied />} />
-      <Route path="/unknown-error" element={<UnknownError />} />
+      <Route path="/error" element={<Error />} />
       <Route path="*" element={<NotFound />} />
     </Route>,
   ),

--- a/client/src/pages/AuthorizedLayer/index.tsx
+++ b/client/src/pages/AuthorizedLayer/index.tsx
@@ -8,7 +8,7 @@ import { Outlet, useNavigate } from 'react-router-dom';
  * ## 로그인 한 유저들만 머무를 수 있는 페이지.
  * - 새로고침시 토큰 갱신을 시도하며, 로그인하지 않은(유저 상태나 액세스 토큰 상태가 없는) 유저가 접근하면 **`/`** 로 리다이렉트된다.
  * - 토큰 갱신 요청시, 유효하지 않은 토큰 에러가 발생하면 **`/sign-in`** 으로 리다이렉트 된다.
- * - 토큰 갱신 요청시, 알 수 없는 에러가 발생하면 **`/unknown-error`** 로 리다이렉트 된다.
+ * - 토큰 갱신 요청시, 알 수 없는 에러가 발생하면 **`/error`** 로 리다이렉트 된다.
  */
 const AuthorizedLayer = () => {
   const user = useMyInfoQueryData();
@@ -16,9 +16,18 @@ const AuthorizedLayer = () => {
   const accessToken = useTokenStore((state) => state.accessToken);
   const navigate = useNavigate();
 
-  const reissueTokenMutation = useReissueTokenMutation(() => {
-    navigate('/sign-in', { state: { alreadyTriedReissueToken: true } });
-  }, '/unknown-error');
+  const reissueTokenMutation = useReissueTokenMutation(
+    () => {
+      navigate('/sign-in', { state: { alreadyTriedReissueToken: true } });
+    },
+    () => {
+      navigate('/error', {
+        state: {
+          summary: '로그인중 오류가 발생했습니다. 잠시 뒤에 다시 시도해주세요.',
+        },
+      });
+    },
+  );
 
   useEffect(() => {
     if (user || accessToken) return;

--- a/client/src/pages/Error/index.tsx
+++ b/client/src/pages/Error/index.tsx
@@ -23,7 +23,7 @@ const initialDisplayFallbacks = [
   },
 ];
 
-const UnknownError: FC<Props> = ({
+const Error: FC<Props> = ({
   title = initialDisplayTitle,
   summary = initialDisplaySummary,
   fallbacks = initialDisplayFallbacks,
@@ -76,4 +76,4 @@ const UnknownError: FC<Props> = ({
   );
 };
 
-export default UnknownError;
+export default Error;

--- a/client/src/pages/NotFound/index.tsx
+++ b/client/src/pages/NotFound/index.tsx
@@ -15,7 +15,7 @@ const NotFound = () => {
                 Page Not Found
               </h2>
               <div className="text-[30px] text-label">
-                요청하신 페이지를{' '}
+                요청하신 페이지를
                 <span className="text-primary-dark font-bold">
                   찾을 수 없습니다.
                 </span>

--- a/client/src/pages/UnknownError/index.tsx
+++ b/client/src/pages/UnknownError/index.tsx
@@ -1,9 +1,79 @@
+import type { FC } from 'react';
+
 import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
-const UnknownError = () => {
-  console.log(`[${location.pathname}]`);
+interface Fallback {
+  name: string;
+  url: string;
+}
 
-  return <div>Unknown Error</div>;
+interface Props {
+  title?: string;
+  summary?: string;
+  fallbacks?: Fallback[];
+}
+
+const initialDisplayTitle = 'ERROR';
+const initialDisplaySummary = '알 수 없는 에러가 발생했습니다.';
+const initialDisplayFallbacks = [
+  {
+    name: '홈으로 되돌아가기',
+    url: '/',
+  },
+];
+
+const UnknownError: FC<Props> = ({
+  title = initialDisplayTitle,
+  summary = initialDisplaySummary,
+  fallbacks = initialDisplayFallbacks,
+}) => {
+  const location = useLocation();
+  const locationState = location?.state;
+
+  let displayTitle = title;
+  let displaySummary = summary;
+  let displayFallbacks = fallbacks;
+
+  if (locationState) {
+    const {
+      title: _title,
+      summary: _summary,
+      fallbacks: _fallbacks,
+    } = locationState;
+
+    displayTitle = _title ?? displayTitle;
+    displaySummary = _summary ?? displaySummary;
+    displayFallbacks = _fallbacks ?? displayFallbacks;
+  }
+
+  return (
+    <main className="wrapper flex flex-1 bg-inputBackground">
+      <div className="flex flex-col min-w-[720px] w-full h-[80vh] justify-center items-center pt-[100px]">
+        <div>
+          <div className="flex flex-col items-center">
+            <div className="flex flex-col items-center mb-4">
+              <h2 className="font-bold text-[60px] tracking-tighter">
+                {displayTitle}
+              </h2>
+              <div className="text-[30px] text-label">{displaySummary}</div>
+            </div>
+            <div className="flex gap-2">
+              {displayFallbacks.map((fallback, idx) => (
+                <Link
+                  key={idx}
+                  to={fallback.url}
+                  className="block underline bg-offWhite rounded-lg p-1 hover:text-secondary"
+                >
+                  <div className="font-bold">{fallback.name}</div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
 };
 
 export default UnknownError;

--- a/client/src/routes/HomeErrorElement.tsx
+++ b/client/src/routes/HomeErrorElement.tsx
@@ -9,7 +9,15 @@ const HomeErrorElement = () => {
 
   if (errorCount >= maxErrorCount) {
     errorCount = 0;
-    return <Navigate to="/unknown-error" />;
+    return (
+      <Navigate
+        to="/error"
+        state={{
+          summary:
+            '알 수 없는 에러가 여러번 감지되었습니다. 잠시 뒤에 다시 시도해주세요.',
+        }}
+      />
+    );
   }
 
   return <Navigate to="/" />;


### PR DESCRIPTION
## Issues
- #327 

## 🤷‍♂️ Description

에러 페이지 구현.


## 📝 Primary Commits

- [X] 에러 페이지 구현
- [X] 에러 페이지 라우팅 경로 변경
- [X] 라우팅 경로 변경에 따라 에러 페이지로 리다이렉트하는 코드 있는 컴포넌트들 리팩토링


## 📷 Screenshots

![image](https://user-images.githubusercontent.com/79135734/206891221-1d26569a-5943-4ed5-ace7-1fdbb4d0f341.png)
 
## 📒 Remarks
 
위 페이지는 기본값인데 각 텍스트는 다음과 같이 상태로 반영 가능
```tsx
<Navigate
  to="/error"
  state={{
    title: 'ERROR',
    summary: '알 수 없는 에러가 발생했습니다.',
    fallbacks: [{ name: '홈으로 되돌아가기', url: '/' }],
  }}
/>;

// 또는

const fallbacks = [{ name: '홈으로 되돌아가기', url: '/' }];
<Error
  title="ERROR"  
  summary="알 수 없는 에러가 발생했습니다." 
  fallbacks={fallbacks}  
/>
```

- 웬만하면 그냥 기본값 사용하기.
- 채팅 수정 PR 커밋이 반영되어 있기 때문에, 실제로는 커밋 5개밖에 없습니다.
