### PR TITLE
[Server/Feature] 커뮤니티에 안읽은 채팅 있는지 확인하는 로직

### DIFF
--- a/server/apps/api/src/channel/channel.controller.ts
+++ b/server/apps/api/src/channel/channel.controller.ts
@@ -15,7 +15,12 @@ export class ChannelController {
   async createChannel(@ReceivedData(userToManagerPipe) createChannelDto: CreateChannelDto) {
     const newChannel = await this.channelService.createChannel(createChannelDto);
     await this.botService.infoMakeChannel(newChannel._id, createChannelDto.nickname);
-
+    const updateLastReadDto = {
+      requestUserId: newChannel.managerId,
+      community_id: newChannel.communityId,
+      channel_id: newChannel._id,
+    };
+    await this.channelService.updateLastRead(updateLastReadDto);
     delete newChannel.users;
     return newChannel;
   }

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -28,6 +28,11 @@ export class ChannelService {
     const { communityId, isPrivate, managerId } = createChannelDto;
     // 자신이 속한 커뮤니티 찾기
     const community = await this.communityRepository.findById(communityId);
+
+    if (!community) throw new BadRequestException('커뮤니티가 없습니다.');
+    if (community.deletedAt) throw new BadRequestException('삭제된 커뮤니티 입니다.');
+    if (!community.users.includes(managerId))
+      throw new BadRequestException('커뮤니티에 존재하지 않는 유저입니다.');
     // 채널 생성
     const channel = await this.channelRepository.create(createChannelDto);
     // community 도큐먼트의 channel 필드 업데이트

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -27,10 +27,13 @@ export class ChannelService {
   async createChannel(createChannelDto: CreateChannelDto) {
     const { communityId, isPrivate, managerId } = createChannelDto;
     // 자신이 속한 커뮤니티 찾기
-    const community = await this.communityRepository.findById(communityId);
+    // const community = await this.communityRepository.findById(communityId);
+    const community = await this.communityRepository.findOne({
+      _id: communityId,
+      deletedAt: undefined,
+    });
 
     if (!community) throw new BadRequestException('커뮤니티가 없습니다.');
-    if (community.deletedAt) throw new BadRequestException('삭제된 커뮤니티 입니다.');
     if (!community.users.includes(managerId))
       throw new BadRequestException('커뮤니티에 존재하지 않는 유저입니다.');
     // 채널 생성
@@ -56,11 +59,13 @@ export class ChannelService {
     // 채널의 관리자가 아니면 예외처리
     const channel = await this.channelRepository.findOne({
       _id: channel_id,
-      managerId: requestUserId,
+      deletedAt: undefined,
     });
     if (!channel) {
-      throw new UnauthorizedException('채널 관리자가 아닙니다.');
+      throw new UnauthorizedException('존재하지 않는 채널입니다.');
     }
+    if (channel.managerId !== requestUserId)
+      throw new UnauthorizedException('채널 관리자가 아닙니다.');
 
     // 채널 수정
     try {
@@ -71,7 +76,8 @@ export class ChannelService {
   }
 
   async getChannelInfo(channel_id) {
-    const channel = await this.channelRepository.findOne({ _id: channel_id });
+    const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
+    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
     const users = await Promise.all(
       channel.users.map(async (user_id) => {
         const user = await this.userRepository.findById(user_id);
@@ -86,7 +92,11 @@ export class ChannelService {
     const { channel_id, requestUserId } = exitChannelDto;
 
     // channel 관리자이고 channel의 users에 2명이상 존재 시 채널 퇴장 불가능
-    const channel = await this.channelRepository.findById(channel_id);
+    const channel = await this.channelRepository.findOne({
+      channel_id: channel_id,
+      deletedAt: undefined,
+    });
+    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
     if (requestUserId === channel.managerId) {
       if (channel.users.length > 1) {
         throw new BadRequestException('관리자를 변경하고 채널을 퇴장하십시오!');
@@ -109,7 +119,8 @@ export class ChannelService {
   async deleteChannel(deleteChannelDto: DeleteChannelDto) {
     const { channel_id, requestUserId } = deleteChannelDto;
     // 관리자가 아니면 채널 삭제 에러 처리
-    const channel = await this.channelRepository.findById(channel_id);
+    const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
+    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
     if (requestUserId !== channel.managerId) {
       throw new BadRequestException('관리자가 아닙니다!');
     }
@@ -141,8 +152,12 @@ export class ChannelService {
 
   async inviteChannel(inviteChannelDto: InviteChannelDto) {
     const { community_id, channel_id, users } = inviteChannelDto;
+    const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
+    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
+
     await this.checkUserInCommunity(community_id, users);
     await this.addUserToChannel(community_id, channel_id, users);
+
     const channelInfo = getChannelBasicInfo(await this.channelRepository.findById(channel_id));
     if (!channelInfo) throw new BadRequestException();
     return { ...channelInfo, lastRead: false };
@@ -150,6 +165,9 @@ export class ChannelService {
 
   async updateLastRead(updateLastReadDto: UpdateLastReadDto) {
     const { community_id, channel_id, requestUserId } = updateLastReadDto;
+    const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
+    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
+
     // 유저 도큐먼트의 커뮤니티:채널 필드 업데이트
     await this.userRepository.updateObject(
       { _id: requestUserId },
@@ -159,15 +177,23 @@ export class ChannelService {
 
   async joinChannel(joinChannelDto: JoinChannelDto) {
     const { requestUserId, channel_id, community_id } = joinChannelDto;
+    const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
+    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
+
     await this.checkUserInCommunity(community_id, [requestUserId]);
     await this.addUserToChannel(community_id, channel_id, [requestUserId]);
+
     const channelInfo = getChannelBasicInfo(await this.channelRepository.findById(channel_id));
     if (!channelInfo) throw new BadRequestException();
     return { ...channelInfo, lastRead: false };
   }
 
   async checkUserInCommunity(community_id, newUsers) {
-    const community = await this.communityRepository.findById(community_id);
+    const community = await this.communityRepository.findOne({
+      _id: community_id,
+      deletedAt: undefined,
+    });
+    if (!community) throw new UnauthorizedException('존재하지 않는 커뮤니티 입니다.');
     const userSet = new Set(community.users);
     newUsers.map((user) => {
       if (!userSet.has(user)) {

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -100,6 +100,9 @@ export class ChatListService {
         R = M - 1;
       }
     }
+    if (new Date(unreadChatList[M].createdAt) < lastRead) {
+      return -1;
+    }
     return unreadChatList[M].id;
   }
 }

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -5,6 +5,7 @@ import { ChatListRespository } from '@repository/chat-list.respository';
 import { GetUnreadMessagePointDto } from '@chat-list/dto/get-unread-message-point.dto';
 import { UserRepository } from '@repository/user.repository';
 import { makeChat } from '@chat-list/helper/makeChat';
+import { NOT_EXIST_UNREAD_CHAT } from '@utils/def';
 
 @Injectable()
 export class ChatListService {
@@ -101,7 +102,7 @@ export class ChatListService {
       }
     }
     if (new Date(unreadChatList[M].createdAt) < lastRead) {
-      return -1;
+      return NOT_EXIST_UNREAD_CHAT;
     }
     return unreadChatList[M].id;
   }

--- a/server/apps/api/src/community/community.module.ts
+++ b/server/apps/api/src/community/community.module.ts
@@ -10,12 +10,14 @@ import { ChannelModule } from '@api/src/channel/channel.module';
 import { ChannelRepository } from '@repository/channel.repository';
 import { CommunitiesController } from '@community/communities.controller';
 import { ChatListRespository } from '@repository/chat-list.respository';
+import { ChatListModule } from '@chat-list/chat-list.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Community.name, schema: CommunitySchema }]),
     UserModule,
     forwardRef(() => ChannelModule),
+    ChatListModule,
   ],
   controllers: [CommunityController, CommunitiesController],
   providers: [

--- a/server/apps/api/src/community/community.module.ts
+++ b/server/apps/api/src/community/community.module.ts
@@ -9,6 +9,7 @@ import { UserModule } from '@user/user.module';
 import { ChannelModule } from '@api/src/channel/channel.module';
 import { ChannelRepository } from '@repository/channel.repository';
 import { CommunitiesController } from '@community/communities.controller';
+import { ChatListRespository } from '@repository/chat-list.respository';
 
 @Module({
   imports: [
@@ -17,7 +18,13 @@ import { CommunitiesController } from '@community/communities.controller';
     forwardRef(() => ChannelModule),
   ],
   controllers: [CommunityController, CommunitiesController],
-  providers: [CommunityService, CommunityRepository, UserRepository, ChannelRepository],
+  providers: [
+    CommunityService,
+    CommunityRepository,
+    UserRepository,
+    ChannelRepository,
+    ChatListRespository,
+  ],
   exports: [MongooseModule],
 })
 export class CommunityModule {}

--- a/server/apps/api/src/community/community.service.ts
+++ b/server/apps/api/src/community/community.service.ts
@@ -53,15 +53,17 @@ export class CommunityService {
               throw new BadRequestException('존재하지 않는 채널입니다.');
             }
             const channelInfo = getChannelBasicInfo(channel);
-            // TODO : channel document의 updatedAt 아니고 다르값 비교
+            // 안읽은 채팅 있는 지 확인
             const lastRead = new Date(
               JSON.parse(JSON.stringify(user)).communities[`${channel.communityId}`].channels[
                 `${channel._id}`
               ],
             );
-            const lastChatList = await this.chatListRepository.findById(channel.chatLists.at(-1));
+            const lastChatList = JSON.parse(
+              JSON.stringify(await this.chatListRepository.findById(channel.chatLists.at(-1))),
+            );
             const lastChatTime = lastChatList.chat.at(-1).createdAt;
-            lastRead.getTime() >= lastChatTime;
+            channelInfo['existUnreadChat'] = lastRead.getTime() <= new Date(lastChatTime).getTime();
             channelsInfo.push(channelInfo);
           }),
         );

--- a/server/apps/api/src/community/community.service.ts
+++ b/server/apps/api/src/community/community.service.ts
@@ -54,16 +54,11 @@ export class CommunityService {
             }
             const channelInfo = getChannelBasicInfo(channel);
             // 안읽은 채팅 있는 지 확인
-            const lastRead = new Date(
-              JSON.parse(JSON.stringify(user)).communities[`${channel.communityId}`].channels[
-                `${channel._id}`
-              ],
-            );
-            const lastChatList = JSON.parse(
-              JSON.stringify(await this.chatListRepository.findById(channel.chatLists.at(-1))),
-            );
+            const lastChatList = await this.chatListRepository.findById(channel.chatLists.at(-1));
+
             const lastChatTime = lastChatList.chat.at(-1).createdAt;
-            channelInfo['existUnreadChat'] = lastRead.getTime() <= new Date(lastChatTime).getTime();
+            channelInfo['existUnreadChat'] =
+              channels.get(channelId).getTime() <= new Date(lastChatTime).getTime();
             channelsInfo.push(channelInfo);
           }),
         );

--- a/server/dao/schemas/chat.schema.ts
+++ b/server/dao/schemas/chat.schema.ts
@@ -30,6 +30,5 @@ export class Chat {
 
   @Prop({ type: mongoose.Schema.Types.Date })
   deletedAt: Date;
-  Ï;
 }
 export const ChatSchema = SchemaFactory.createForClass(Chat);

--- a/server/utils/def.ts
+++ b/server/utils/def.ts
@@ -3,3 +3,4 @@ export const PROVIDER = ['ASNITY', 'GITHUB'];
 export const CHANNEL_TYPE = ['CHANNEL', 'DM'];
 export const CHAT_TYPE = ['TEXT', 'IMAGE', 'SYSTEM'];
 export const BOT_ID = '639045fc61d68253e03c50da';
+export const NOT_EXIST_UNREAD_CHAT = -1;


### PR DESCRIPTION
## Issues
- #334
## 🤷‍♂️ Description

사용자는 다른 커뮤니티, 채널에 안읽은 메세지 여부를 알 수 있다.

- 자신이 속한 커뮤니티, 채널 정보 가져올 때 채널에 안읽은 채팅 존재 여부 확인
- 채널 생성 예외처리 추가
- 안읽은 메세지 없을 경우 응답으로 -1을 보냄
- 채널 생성 시 마지막 방문시간 업데이트

## 📷 Screenshots
>**커뮤니티 안읽은 채팅 여부 업데이트**
1. 커뮤니티 정보 가져옴 -> 채널에 안읽은 메세지 없음

<img width="408" alt="스크린샷 2022-12-11 오후 6 18 09" src="https://user-images.githubusercontent.com/72093196/206899703-37e3fa26-a70d-4b3c-b460-ec84bdb5ce73.png">

**채널에 메세지 생성**

2. 커뮤니티 정보 가져옴 -> 채널에 안읽은 메세지 있음

<img width="383" alt="스크린샷 2022-12-11 오후 6 18 29" src="https://user-images.githubusercontent.com/72093196/206899706-5ed1f32b-cb53-4b07-bb69-4175ae21ff3a.png">

**채널 마지막 방문 시간 업데이트**

3. 커뮤니티 정보 가져옴 -> 채널에 안읽은 메세지 없음


<img width="354" alt="스크린샷 2022-12-11 오후 6 18 46" src="https://user-images.githubusercontent.com/72093196/206899710-38947335-7bfb-42f9-98d5-8e247a862d4b.png">


