### PR TITLE
[Server/chat] 채팅 수정 기능 구현

### DIFF
--- a/server/apps/api/src/chat-list/chat-list.controller.ts
+++ b/server/apps/api/src/chat-list/chat-list.controller.ts
@@ -1,10 +1,14 @@
-import { Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Controller, Get, Patch, Post, UseGuards } from '@nestjs/common';
 import { ChatListService } from '@chat-list/chat-list.service';
 import { JwtAccessGuard } from '@auth/guard';
-import { GetMessageDto, RestoreMessageDto } from '@chat-list/dto';
+import {
+  GetMessageDto,
+  GetUnreadMessagePointDto,
+  ModifyMessageDto,
+  RestoreMessageDto,
+} from '@chat-list/dto';
 import { ReceivedData } from '@custom/decorator/ReceivedData.decorator';
 import { userToSenderPipe } from '@custom/pipe/userToSender.pipe';
-import { GetUnreadMessagePointDto } from '@chat-list/dto/get-unread-message-point.dto';
 
 @Controller('api/channels')
 export class ChatListController {
@@ -27,5 +31,11 @@ export class ChatListController {
   async getUnreadMessagePoint(@ReceivedData() getUnreadMessageDto: GetUnreadMessagePointDto) {
     const unreadChatId = await this.chatListService.getUnreadMessagePoint(getUnreadMessageDto);
     return { unreadChatId };
+  }
+
+  @Patch(':channel_id/chats/:chat_id')
+  @UseGuards(JwtAccessGuard)
+  async modifyMessage(@ReceivedData() modifyMessageDto: ModifyMessageDto) {
+    return await this.chatListService.modifyMessage(modifyMessageDto);
   }
 }

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -136,11 +136,12 @@ export class ChatListService {
 
     await this.chatListRespository.updateOne({ _id: chatList._id }, chatList);
 
-    chatList.chat[chatNum]['channelId'] = channel_id;
-    chatList.chat[chatNum]['communityId'] = channel.communityId;
-    chatList.chat[chatNum]['chatId'] = chat_id;
     delete chatList.chat[chatNum].id;
-
-    return chatList.chat[chatNum];
+    return {
+      ...chatList.chat[chatNum],
+      channelId: channel_id,
+      communityId: channel.communityId,
+      chatId: chat_id,
+    };
   }
 }

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -136,7 +136,8 @@ export class ChatListService {
 
     await this.chatListRespository.updateOne({ _id: chatList._id }, chatList);
 
-    chatList.chat[chatNum]['community_id'] = channel.communityId;
+    chatList.chat[chatNum]['channelId'] = channel_id;
+    chatList.chat[chatNum]['communityId'] = channel.communityId;
     chatList.chat[chatNum]['chatId'] = chat_id;
     delete chatList.chat[chatNum].id;
 

--- a/server/apps/api/src/chat-list/dto/index.ts
+++ b/server/apps/api/src/chat-list/dto/index.ts
@@ -1,2 +1,4 @@
 export * from './restore-message.dto';
 export * from './get-message.dto';
+export * from './get-unread-message-point.dto';
+export * from './modify-message.dto';

--- a/server/apps/api/src/chat-list/dto/modify-message.dto.ts
+++ b/server/apps/api/src/chat-list/dto/modify-message.dto.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { IsMongoId, IsNotEmpty, IsString } from 'class-validator';
+
+@Injectable()
+export class ModifyMessageDto {
+  @IsMongoId()
+  @IsNotEmpty()
+  requestUserId: string;
+
+  @IsMongoId()
+  @IsNotEmpty()
+  channel_id: string;
+
+  @IsNotEmpty()
+  chat_id;
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+}


### PR DESCRIPTION
## Issues
- #341 

## 🤷‍♂️ Description

채널 사용자는 자신의 채팅을 수정할 수 있다.

## 📷 Screenshots
<img width="492" alt="스크린샷 2022-12-12 오전 3 10 42" src="https://user-images.githubusercontent.com/72093196/206921053-d6aaa380-b86f-403a-8a85-fcffd48a8152.png">

## 📒 Remarks
- [x]  ModiftMessage.dto
    
    ```tsx
    requestUserId : mongoId, notEmpty
    channel_id: mongoId, notEmpty
    chat_id: mongoId, notEmpty
    content: string, notEmpty
    ```
    
- [x]  chat-list.controller.ts
    - Patch `api/channel/:channel_id/chats/:chat_id`
- [x]  chat-list.service.ts
    - chat_id에 해당하는 메세지를 찾음
    - requestUserId와 senderId가 일치하는지 검증
    - chat 수정
    - 응답 생성
    
    ```
    {
        "type": "TEXT",
        "content": "hi",
        "channelId": "6394cd01d1a615bf564d9e4c",
        "senderId": "6394cc8fd1a615bf564d7e75",
        "chatId": 51,
        "communityId" : "",
        "createdAt": Date(),
        "updatedAt": Date(),
    }
    ```

