### PR TITLE
[Server/channel] 채널 버그 해결, 채팅 응답 수정

### DIFF
--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -93,16 +93,17 @@ export class ChannelService {
 
     // channel 관리자이고 channel의 users에 2명이상 존재 시 채널 퇴장 불가능
     const channel = await this.channelRepository.findOne({
-      channel_id: channel_id,
+      _id: channel_id,
       deletedAt: undefined,
     });
+
     if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
     if (requestUserId === channel.managerId) {
       if (channel.users.length > 1) {
         throw new BadRequestException('관리자를 변경하고 채널을 퇴장하십시오!');
       }
       // 관리자 혼자 채널에 존재하고 채널을 나갈 경우 채널 제거
-      this.deleteChannel({ channel_id, requestUserId });
+      await this.deleteChannel({ channel_id, requestUserId });
     }
 
     // channel도큐먼트에 users필드에서 user_id 제거
@@ -121,6 +122,7 @@ export class ChannelService {
     // 관리자가 아니면 채널 삭제 에러 처리
     const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
     if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
+
     if (requestUserId !== channel.managerId) {
       throw new BadRequestException('관리자가 아닙니다!');
     }
@@ -160,7 +162,7 @@ export class ChannelService {
 
     const channelInfo = getChannelBasicInfo(await this.channelRepository.findById(channel_id));
     if (!channelInfo) throw new BadRequestException();
-    return { ...channelInfo, lastRead: false };
+    return { ...channelInfo, existUnreadChat: false };
   }
 
   async updateLastRead(updateLastReadDto: UpdateLastReadDto) {

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -44,7 +44,7 @@ export class ChatListService {
 
     return {
       ...restoreMessageDto,
-      chatId: chatNum,
+      id: +chatNum,
       communityId: channel.communityId,
       createdAt: date,
       updatedAt: date,
@@ -136,12 +136,11 @@ export class ChatListService {
 
     await this.chatListRespository.updateOne({ _id: chatList._id }, chatList);
 
-    delete chatList.chat[chatNum].id;
     return {
       ...chatList.chat[chatNum],
       channelId: channel_id,
       communityId: channel.communityId,
-      chatId: chat_id,
+      id: +chat_id,
     };
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description

- 채널 관리자가 채널에 유저가 2명 이상 존재하는데 나갈 수 있는 이슈 해결
  - `findOne{channel_id: channel_id}` -> `findOne{_id: channel_id}`
  - delete하는 부분 동기처리

- 채팅 응답 수정
  - `chatId` -> `id`