### PR TITLE
[Server/chat] 채팅 수정 리팩토링 및 채팅 삭제 기능 추가

### DIFF
--- a/server/apps/api/src/chat-list/chat-list.controller.ts
+++ b/server/apps/api/src/chat-list/chat-list.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Patch, Post, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, Patch, Post, UseGuards } from '@nestjs/common';
 import { ChatListService } from '@chat-list/chat-list.service';
 import { JwtAccessGuard } from '@auth/guard';
 import {
@@ -9,6 +9,7 @@ import {
 } from '@chat-list/dto';
 import { ReceivedData } from '@custom/decorator/ReceivedData.decorator';
 import { userToSenderPipe } from '@custom/pipe/userToSender.pipe';
+import { DeleteMessageDto } from '@chat-list/dto/delete-message.dto';
 
 @Controller('api/channels')
 export class ChatListController {
@@ -37,5 +38,11 @@ export class ChatListController {
   @UseGuards(JwtAccessGuard)
   async modifyMessage(@ReceivedData() modifyMessageDto: ModifyMessageDto) {
     return await this.chatListService.modifyMessage(modifyMessageDto);
+  }
+
+  @Delete(':channel_id/chats/:chat_id')
+  @UseGuards(JwtAccessGuard)
+  async deleteMessage(@ReceivedData() deleteMessageDto: DeleteMessageDto) {
+    return await this.chatListService.deleteMessage(deleteMessageDto);
   }
 }

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -137,7 +137,10 @@ export class ChatListService {
 
     const date = new Date();
 
-    await this.chatListRespository.updateChatAtChatList(chatList._id, +chat_id, content, date);
+    await this.chatListRespository.updateOne(
+      { _id: chatList._id, 'chat.id': +chat_id },
+      { $set: { 'chat.$.content': content, 'chat.$.updatedAt': date } },
+    );
 
     const result = {
       ...chatList.chat[chatNum],
@@ -171,7 +174,10 @@ export class ChatListService {
 
     const date = new Date();
 
-    await this.chatListRespository.deleteChatAtChatList(chatList._id, +chat_id, date);
+    await this.chatListRespository.updateOne(
+      { _id: chatList._id, 'chat.id': +chat_id },
+      { $set: { 'chat.$.updatedAt': date, 'chat.$.deletedAt': date } },
+    );
 
     const result = {
       ...chatList.chat[chatNum],

--- a/server/apps/api/src/chat-list/dto/delete-message.dto.ts
+++ b/server/apps/api/src/chat-list/dto/delete-message.dto.ts
@@ -1,0 +1,14 @@
+import { IsMongoId, IsNotEmpty } from 'class-validator';
+
+export class DeleteMessageDto {
+  @IsMongoId()
+  @IsNotEmpty()
+  requestUserId: string;
+
+  @IsMongoId()
+  @IsNotEmpty()
+  channel_id: string;
+
+  @IsNotEmpty()
+  chat_id;
+}

--- a/server/dao/repository/chat-list.respository.ts
+++ b/server/dao/repository/chat-list.respository.ts
@@ -22,4 +22,17 @@ export class ChatListRespository {
   async updateOne(filter, updateField) {
     return await this.chatListModel.updateOne(filter, updateField);
   }
+
+  async updateChatAtChatList(chatListId, chatId, content, date) {
+    await this.chatListModel.updateOne(
+      { _id: chatListId, 'chat.id': chatId },
+      { $set: { 'chat.$.content': content, 'chat.$.updatedAt': date } },
+    );
+  }
+  async deleteChatAtChatList(chatListId, chatId, date) {
+    await this.chatListModel.updateOne(
+      { _id: chatListId, 'chat.id': chatId },
+      { $set: { 'chat.$.updatedAt': date, 'chat.$.deletedAt': date } },
+    );
+  }
 }

--- a/server/dao/repository/chat-list.respository.ts
+++ b/server/dao/repository/chat-list.respository.ts
@@ -22,17 +22,4 @@ export class ChatListRespository {
   async updateOne(filter, updateField) {
     return await this.chatListModel.updateOne(filter, updateField);
   }
-
-  async updateChatAtChatList(chatListId, chatId, content, date) {
-    await this.chatListModel.updateOne(
-      { _id: chatListId, 'chat.id': chatId },
-      { $set: { 'chat.$.content': content, 'chat.$.updatedAt': date } },
-    );
-  }
-  async deleteChatAtChatList(chatListId, chatId, date) {
-    await this.chatListModel.updateOne(
-      { _id: chatListId, 'chat.id': chatId },
-      { $set: { 'chat.$.updatedAt': date, 'chat.$.deletedAt': date } },
-    );
-  }
 }


### PR DESCRIPTION
## Issues
- #341  
- #357 

## 🤷‍♂️ Description

채널 사용자는 자신의 채팅을 삭제할 수 있다.

- 채팅 받아올 때 삭제된거 제외하고 받도록 수정
- 채팅 수정, 삭제를 위한 쿼리 작성
- 채팅 수정시 chatList 전부 교체하는 방식 -> 일부만 수정하도록 코드 리팩토링
- 채팅 삭제 기능 구현

## 📷 Screenshots

https://user-images.githubusercontent.com/72093196/206984891-951bf4da-e923-4f8c-af62-bb1fcf37ee99.mov


 
## 📒 Remarks


>**채팅 삭제**
- [x]  DeleteMessageDto
    
    ```
    requestUserId: MongoId, NotEmpty
    channelId: MongoId, NotEmpty
    chatId: NotEmpty
    ```
    
- [x]  chat-list.controller
    - DELETE `api/channel/:channel_id/chats/:chat_id`
- [x]  chat-list.service
    - 채널이 존재하는지 확인
    - requestUserId와 senderId가 일치하는지 검증
    - deletedAt 추가
    - 응답
        
        ```
        "id": 51,
        "type": "TEXT",
        "content": "hi",
        "createdAt": Date(),
        "updatedAt": Date(),
        "deletedAt": Date(),
        "senderId": "6394cc8fd1a615bf564d7e75",
        "communityId" : "",
        "channelId": "6394cd01d1a615bf564d9e4c",
        ```
