### PR TITLE
[CLIENT] 안 읽은 메시지 채널 페이지 내에 렌더링

### DIFF
--- a/client/src/apis/chat.ts
+++ b/client/src/apis/chat.ts
@@ -37,3 +37,20 @@ export const getChats: GetChats = (channelId, prev) => {
     .get<GetChatsResponse>(_endPoint, { params: { prev } })
     .then((response) => response.data.result);
 };
+
+export type GetUnreadChatIdResult = {
+  unreadChatId: number;
+};
+
+export type GetUnreadChatIdResponse = SuccessResponse<GetUnreadChatIdResult>;
+export type GetUnreadChatId = (
+  channelId: string,
+) => Promise<GetUnreadChatIdResult['unreadChatId']>;
+
+export const getUnreadChatId: GetUnreadChatId = (channelId) => {
+  const _endPoint = endPoint.getUnreadChatId(channelId);
+
+  return tokenAxios
+    .get<GetUnreadChatIdResponse>(_endPoint)
+    .then((response) => response.data.result.unreadChatId);
+};

--- a/client/src/components/ChatList/index.tsx
+++ b/client/src/components/ChatList/index.tsx
@@ -40,13 +40,14 @@ const ChatList: FC<Props> = ({
 
   // 캐시에 있는 안 읽은 메시지의 id를 가져온다.
   const cachedUnreadChatId = useUnreadChatIdQueryData(channelId) as number;
-  // 채널 입장 시의 안 읽은 메시지의 id를 저장한다.
+  // 채널 입장 시의 캐시에 저장되어있는 안 읽은 메시지의 id를 저장한다.
   const firstUnreadChatId = useRef<number | null>(null);
 
   useEffect(() => {
     // 이렇게 해야 divider가 화면에 보여서
     // clearUnreadChatIdQueryData()를 실행하여 캐시에 -1로 저장해도
-    // firstUnreadChatId는 -1이 아니라 첫 렌더링 시의 안 읽은 메시지의 id를 저장하게 된다.
+    // firstUnreadChatId는 현재 캐시에 저장된 -1이 아니라
+    // 첫 렌더링 시의 캐시에 저장된 안 읽은 메시지의 id를 저장하게 된다.
     if (!firstUnreadChatId.current) {
       firstUnreadChatId.current = cachedUnreadChatId;
     }
@@ -60,12 +61,15 @@ const ChatList: FC<Props> = ({
             <Fragment key={page.chat[0].id}>
               {page.chat.map((chat) => (
                 <Fragment key={chat.id}>
-                  {/* chat의 id가 첫 렌더링 시의 안 읽은 메시지의 id와 같다면 divider를 렌더링한다*/}
+                  {/* chat의 id가 첫 렌더링 시의 캐시에 저장된 안 읽은 메시지의 id와 같다면 divider를 렌더링한다.
+                  최신 캐시에 있는 안 읽은 메시지의 id와 비교하지 않으므로 해당 값이 -1로 바뀌어도
+                  divider는 사라지지 않는다.
+                  */}
                   {chat.id === firstUnreadChatId.current && (
                     <div
                       className="flex items-center relative h-0 my-3 border-b-[1px] border-error"
                       ref={
-                        /* 캐시에 저장된 안 읽은 메시지의 ㅑㅇ가 -1이 되면 divider에 더이상 
+                        /* 캐시에 저장된 안 읽은 메시지의 id가 -1이 되면 divider에 더이상 
                         observable ref가 붙지 않도록 한다*/
                         chat.id === cachedUnreadChatId
                           ? firstUnreadChatObservable

--- a/client/src/components/ChatList/index.tsx
+++ b/client/src/components/ChatList/index.tsx
@@ -27,11 +27,9 @@ const ChatList: FC<Props> = ({
   const params = useParams();
   const channelId = params.roomId as string;
 
-  // 캐시에 있는 안 읽은 메시지의 id를 -1로 초기화하는 커스텀 훅
+  // unreadChatId = -1이면, 안 읽은 메세지가 없다는 의미.
   const { clearUnreadChatIdQueryData } = useSetUnreadChatIdQueryData(channelId);
   const firstUnreadChatObservable = useIntersectionObservable(
-    // 안 읽은 메시지를 렌더링하는 `<ChatItem />`위의 divider가 화면에 보이면
-    // 캐시에 있는 안 읽은 메시지의 id를 -1로 초기화한다.
     (entry, observer) => {
       observer.unobserve(entry.target);
       clearUnreadChatIdQueryData();
@@ -41,17 +39,7 @@ const ChatList: FC<Props> = ({
   // 캐시에 있는 안 읽은 메시지의 id를 가져온다.
   const cachedUnreadChatId = useUnreadChatIdQueryData(channelId) as number;
   // 채널 입장 시의 캐시에 저장되어있는 안 읽은 메시지의 id를 저장한다.
-  const firstUnreadChatId = useRef<number | null>(null);
-
-  useEffect(() => {
-    // 이렇게 해야 divider가 화면에 보여서
-    // clearUnreadChatIdQueryData()를 실행하여 캐시에 -1로 저장해도
-    // firstUnreadChatId는 현재 캐시에 저장된 -1이 아니라
-    // 첫 렌더링 시의 캐시에 저장된 안 읽은 메시지의 id를 저장하게 된다.
-    if (!firstUnreadChatId.current) {
-      firstUnreadChatId.current = cachedUnreadChatId;
-    }
-  }, []);
+  const firstUnreadChatId = useRef(cachedUnreadChatId);
 
   return (
     <>
@@ -69,7 +57,7 @@ const ChatList: FC<Props> = ({
                     <div
                       className="flex items-center relative h-0 my-3 border-b-[1px] border-error"
                       ref={
-                        /* 캐시에 저장된 안 읽은 메시지의 id가 -1이 되면 divider에 더이상 
+                        /* 캐시에 저장된 안 읽은 메시지의 id가 -1이 되면 divider에 더이상
                         observable ref가 붙지 않도록 한다*/
                         chat.id === cachedUnreadChatId
                           ? firstUnreadChatObservable

--- a/client/src/components/ChatList/index.tsx
+++ b/client/src/components/ChatList/index.tsx
@@ -3,7 +3,13 @@ import type { UsersMap } from '@hooks/user';
 import type { FC } from 'react';
 
 import ChatItem from '@components/ChatItem';
-import React, { Fragment } from 'react';
+import {
+  useSetUnreadChatIdQueryData,
+  useUnreadChatIdQueryData,
+} from '@hooks/chat';
+import useIntersectionObservable from '@hooks/useIntersectionObservable';
+import React, { useEffect, useRef, Fragment } from 'react';
+import { useParams } from 'react-router-dom';
 
 interface Props {
   pages: GetChatsResult[];
@@ -18,6 +24,34 @@ const ChatList: FC<Props> = ({
   communityManagerId,
   channelManagerId,
 }) => {
+  const params = useParams();
+  const channelId = params.roomId as string;
+
+  // 캐시에 있는 안 읽은 메시지의 id를 -1로 초기화하는 커스텀 훅
+  const { clearUnreadChatIdQueryData } = useSetUnreadChatIdQueryData(channelId);
+  const firstUnreadChatObservable = useIntersectionObservable(
+    // 안 읽은 메시지를 렌더링하는 `<ChatItem />`위의 divider가 화면에 보이면
+    // 캐시에 있는 안 읽은 메시지의 id를 -1로 초기화한다.
+    (entry, observer) => {
+      observer.unobserve(entry.target);
+      clearUnreadChatIdQueryData();
+    },
+  );
+
+  // 캐시에 있는 안 읽은 메시지의 id를 가져온다.
+  const cachedUnreadChatId = useUnreadChatIdQueryData(channelId) as number;
+  // 채널 입장 시의 안 읽은 메시지의 id를 저장한다.
+  const firstUnreadChatId = useRef<number | null>(null);
+
+  useEffect(() => {
+    // 이렇게 해야 divider가 화면에 보여서
+    // clearUnreadChatIdQueryData()를 실행하여 캐시에 -1로 저장해도
+    // firstUnreadChatId는 -1이 아니라 첫 렌더링 시의 안 읽은 메시지의 id를 저장하게 된다.
+    if (!firstUnreadChatId.current) {
+      firstUnreadChatId.current = cachedUnreadChatId;
+    }
+  }, []);
+
   return (
     <>
       {pages.map(
@@ -25,14 +59,32 @@ const ChatList: FC<Props> = ({
           !!page.chat?.length && (
             <Fragment key={page.chat[0].id}>
               {page.chat.map((chat) => (
-                <ChatItem
-                  key={chat.id}
-                  chat={chat}
-                  className="px-5 py-3 tracking-tighter"
-                  user={users[chat.senderId]}
-                  communityManagerId={communityManagerId}
-                  channelManagerId={channelManagerId}
-                />
+                <Fragment key={chat.id}>
+                  {/* chat의 id가 첫 렌더링 시의 안 읽은 메시지의 id와 같다면 divider를 렌더링한다*/}
+                  {chat.id === firstUnreadChatId.current && (
+                    <div
+                      className="flex items-center relative h-0 my-3 border-b-[1px] border-error"
+                      ref={
+                        /* 캐시에 저장된 안 읽은 메시지의 ㅑㅇ가 -1이 되면 divider에 더이상 
+                        observable ref가 붙지 않도록 한다*/
+                        chat.id === cachedUnreadChatId
+                          ? firstUnreadChatObservable
+                          : null
+                      }
+                    >
+                      <span className="flex absolute rounded-xl px-1 right-0 bg-error text-s12 text-offWhite mr-1">
+                        NEW
+                      </span>
+                    </div>
+                  )}
+                  <ChatItem
+                    chat={chat}
+                    className="px-5 py-3 tracking-tighter"
+                    user={users[chat.senderId]}
+                    communityManagerId={communityManagerId}
+                    channelManagerId={channelManagerId}
+                  />
+                </Fragment>
               ))}
             </Fragment>
           ),

--- a/client/src/constants/endPoint.ts
+++ b/client/src/constants/endPoint.ts
@@ -25,6 +25,8 @@ const endPoint = {
     `/api/communities/${communityId}/users` as const,
   getChats: (channelId: string) => `/api/channels/${channelId}/chat`,
   updateLastRead: (channelId: string) => `/api/channels/${channelId}/lastRead`,
+  getUnreadChatId: (channelId: string) =>
+    `/api/channels/${channelId}/unread-chat`,
 } as const;
 
 export default endPoint;

--- a/client/src/constants/regex.ts
+++ b/client/src/constants/regex.ts
@@ -1,5 +1,6 @@
 const REGEX = {
   EMAIL: new RegExp('^\\w+([.-]?\\w+)*@\\w+([.-]?\\w+)*(\\.\\w{2,3})+$'),
+  // CHANENL: ↓↓↓ path parameter에서 커뮤니티 아이디와 채널 아이디를 뽑는다
   CHANNEL: /\/communities\/(?<communityId>\w+)\/channels\/(?<roomId>\w+)/u,
 };
 

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -1,9 +1,13 @@
-import type { Chat, GetChatsResult } from '@apis/chat';
+import type { Chat, GetChatsResult, GetUnreadChatIdResult } from '@apis/chat';
 import type { InfiniteData } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
-import { getChats } from '@apis/chat';
-import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { getUnreadChatId, getChats } from '@apis/chat';
+import {
+  useQuery,
+  useInfiniteQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import produce from 'immer';
 
 import queryKeyCreator from '@/queryKeyCreator';
@@ -383,3 +387,19 @@ export const useSetChatsQueryData = () => {
     removeChatQueryData,
   };
 };
+
+/**
+ *
+ * @param channelId 채널 아이디
+ * @returns 안 읽은 메시지의 위치(id)를 반환한다.
+ */
+export const useUnreadChatIdQuery = (channelId: string) => {
+  const key = queryKeyCreator.chat.unreadChatId(channelId);
+  const query = useQuery<GetUnreadChatIdResult['unreadChatId'], AxiosError>(
+    key,
+    () => getUnreadChatId(channelId),
+  );
+
+  return query;
+};
+

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -420,3 +420,14 @@ export const useSetUnreadChatIdQueryData = (channelId: string) => {
 
   return { clearUnreadChatIdQueryData };
 };
+
+/**
+ * ### 캐시에 저장된 읽지 않은 메시지의 위치(`Chat['id']`)를 가져오기 위해 사용한다.
+ */
+export const useUnreadChatIdQueryData = (channelId: string) => {
+  const key = queryKeyCreator.chat.unreadChatId(channelId);
+  const queryClient = useQueryClient();
+  const unreadChatId = queryClient.getQueryData(key);
+
+  return unreadChatId;
+};

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -403,3 +403,20 @@ export const useUnreadChatIdQuery = (channelId: string) => {
   return query;
 };
 
+/**
+ * ### 캐시에 저장된 읽지 않은 메시지의 위치(`Chat['id']`)를 바꾸기 위해 사용한다.
+ */
+export const useSetUnreadChatIdQueryData = (channelId: string) => {
+  const key = queryKeyCreator.chat.unreadChatId(channelId);
+  const queryClient = useQueryClient();
+
+  /**
+   * ### 캐시에 저장된 읽지 않은 메시지의 위치를 `-1`로 만든다.
+   * => 채널에 안 읽은 메시지가 없도록 만든다.
+   */
+  const clearUnreadChatIdQueryData = () => {
+    queryClient.setQueryData<GetUnreadChatIdResult['unreadChatId']>(key, -1);
+  };
+
+  return { clearUnreadChatIdQueryData };
+};

--- a/client/src/mocks/handlers/Chat.js
+++ b/client/src/mocks/handlers/Chat.js
@@ -42,4 +42,19 @@ const GetChats = rest.get(getChannelEndPoint, (req, res, ctx) => {
   return ERROR ? errorResponse : successResponse;
 });
 
-export default [GetChats];
+const getUnreadChatEndPoint = API_URL + endPoint.getUnreadChatId(':channelId');
+const GetUnreadChatId = rest.get(getUnreadChatEndPoint, (rea, res, ctx) => {
+  const { chats } = chatData;
+  const ERROR = false;
+
+  const errorResponse = res(...createErrorContext(ctx));
+  const successResponse = res(
+    ...createSuccessContext(ctx, 200, 500, {
+      unreadChatId: chats[Math.floor(Math.random() * chats.length)].id,
+    }),
+  );
+
+  return ERROR ? errorResponse : successResponse;
+});
+
+export default [GetChats, GetUnreadChatId];

--- a/client/src/mocks/handlers/Chat.js
+++ b/client/src/mocks/handlers/Chat.js
@@ -1,5 +1,6 @@
 import endPoint from '@constants/endPoint';
 import { API_URL } from '@constants/url';
+import { faker } from '@faker-js/faker';
 import { rest } from 'msw';
 
 import chatData from '../data/chats';
@@ -46,11 +47,13 @@ const getUnreadChatEndPoint = API_URL + endPoint.getUnreadChatId(':channelId');
 const GetUnreadChatId = rest.get(getUnreadChatEndPoint, (rea, res, ctx) => {
   const { chats } = chatData;
   const ERROR = false;
-
+  const existUnreadChat = faker.datatype.boolean();
   const errorResponse = res(...createErrorContext(ctx));
   const successResponse = res(
     ...createSuccessContext(ctx, 200, 500, {
-      unreadChatId: chats[Math.floor(Math.random() * chats.length)].id,
+      unreadChatId: existUnreadChat
+        ? chats[Math.floor(Math.random() * chats.length)].id
+        : -1,
     }),
   );
 

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -67,6 +67,11 @@ const Channel = () => {
   const { addChatsQueryData, updateChatToFailedChat, updateChatToWrittenChat } =
     useSetChatsQueryData();
 
+  /* ======================== [ 안 읽은 메시지 위치 ] ========================== */
+  const unreadChatIdQuery = useUnreadChatIdQuery(roomId);
+  const { clearUnreadChatIdQueryData } = useSetUnreadChatIdQueryData(roomId);
+  const handleMarkAsRead = () => clearUnreadChatIdQueryData();
+
   const handleSubmitChat = (content: string) => {
     if (!socket.isConnected()) {
       defaultSocketErrorHandler();
@@ -107,6 +112,11 @@ const Channel = () => {
     }
   };
 
+  const isLoading =
+    channelWithUsersMap.isLoading ||
+    chatsInfiniteQuery.isLoading ||
+    unreadChatIdQuery.isLoading;
+
   /* ===================== [ 채널 페이지 입장시 전역 스크롤바 설정 ] =================================== */
   useEffect(() => {
     if (scrollbarContainerRef.current !== chatScrollbar) {
@@ -114,10 +124,10 @@ const Channel = () => {
       setChatScrollbar(scrollbarContainerRef.current);
     }
 
-    if (!chatsInfiniteQuery.isLoading) {
+    if (!isLoading) {
       scrollbarContainerRef.current?.scrollToBottom();
     }
-  }, [roomId, chatsInfiniteQuery.isLoading]);
+  }, [roomId, isLoading]);
 
   /* ===================== [ 채널 마지막 방문 시간과 안 읽은 메시지 있음 여부 ] =================================== */
   const { updateExistUnreadChatInChannelQueryData } = useSetChannelQueryData();
@@ -128,24 +138,11 @@ const Channel = () => {
   });
 
   useEffect(() => {
-    // 채널 페이지에 들어올 때 마지막 방문 시간을 업데이트하고 안 읽은 메시지를 없음으로 표시
     updateLastReadMutation.mutate({ communityId, channelId: roomId });
 
-    // 채널 페이지에서 나갈 때 마지막 방문 시간을 업데이트하고 안 읽은 메시지를 없음으로 표시
     return () =>
       updateLastReadMutation.mutate({ communityId, channelId: roomId });
   }, [communityId, roomId]);
-
-  /* ======================== [ 안 읽은 메시지 위치 ] ========================== */
-  const unreadChatIdQuery = useUnreadChatIdQuery(roomId);
-  const { clearUnreadChatIdQueryData } = useSetUnreadChatIdQueryData(roomId);
-  const handleMarkAsRead = () => clearUnreadChatIdQueryData();
-
-  /* ============================== [ 컴포넌트 렌더링 ] =================================== */
-  const isLoading =
-    channelWithUsersMap.isLoading ||
-    chatsInfiniteQuery.isLoading ||
-    unreadChatIdQuery.isLoading;
 
   if (isLoading)
     return (

--- a/client/src/queryClient.ts
+++ b/client/src/queryClient.ts
@@ -4,6 +4,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 5000,
+      refetchOnWindowFocus: false,
     },
   },
 });

--- a/client/src/queryKeyCreator.ts
+++ b/client/src/queryKeyCreator.ts
@@ -46,6 +46,8 @@ const channelQueryKey = {
 const chatQueryKey = {
   all: () => ['chats'] as const,
   list: (channelId: string) => [...chatQueryKey.all(), channelId] as const,
+  unreadChatId: (channelId: string) =>
+    [...chatQueryKey.all(), 'unread-chat-id', channelId] as const,
 };
 
 const queryKeyCreator = {

--- a/client/src/sockets/ClientIO.ts
+++ b/client/src/sockets/ClientIO.ts
@@ -58,6 +58,12 @@ export default class ClientIO {
     payload?: P,
     emitCallback?: C,
   ) {
+    /** socket emit message 3번째에 null 들어가는 이슈 */
+    if (emitCallback) {
+      this.io.emit(eventName, payload);
+      return;
+    }
+
     this.io.emit(eventName, payload, emitCallback);
   }
 


### PR DESCRIPTION
## Issues
- #315 

## 🤷‍♂️ Description

- 채널 페이지 내에서 안 읽은 메시지를 표시해준다.


## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] 채널 페이지 상단에 `위에 안 읽은 메시지가 있어요` 표시
- [X] 안 읽은 메시지 아이템 위에 divider 표시


## 📷 Screenshots

![new message](https://user-images.githubusercontent.com/57662010/207007018-5d76448e-dade-4584-82cf-2893bd3646aa.gif)


 
## 📒 Remarks

- 채널 페이지 첫 입장 시 스크롤 바로 밑으로 안 내려가있는 경우 divider가 제대로 렌더링 안 되는 경우가 있음