### PR TITLE
[Server/channel] 채널 이탈 시 적용되지 않는 이슈 해결

### DIFF
--- a/server/apps/api/src/auth/helper/signToken.ts
+++ b/server/apps/api/src/auth/helper/signToken.ts
@@ -11,7 +11,7 @@ export class SignToken {
       nickname,
     };
     const accessToken = await this.jwt.signAsync(accessTokenPayload, {
-      expiresIn: '15m',
+      expiresIn: '1hr',
       secret: this.config.get('JWT_SECRET'),
     });
     return accessToken;

--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -167,8 +167,12 @@ export class ChannelService {
 
   async updateLastRead(updateLastReadDto: UpdateLastReadDto) {
     const { community_id, channel_id, requestUserId } = updateLastReadDto;
-    const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
-    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
+    const channel = await this.channelRepository.findOne({
+      _id: channel_id,
+      deletedAt: undefined,
+      users: requestUserId,
+    });
+    if (!channel) throw new BadRequestException('사용자가 존재하는 채널이 아닙니다.');
 
     // 유저 도큐먼트의 커뮤니티:채널 필드 업데이트
     await this.userRepository.updateObject(

--- a/server/apps/api/src/chat-list/chat-list.module.ts
+++ b/server/apps/api/src/chat-list/chat-list.module.ts
@@ -8,15 +8,24 @@ import { ChatList, ChatListSchema } from '@schemas/chat-list.schema';
 import { ChannelModule } from '@channel/channel.module';
 import { UserRepository } from '@repository/user.repository';
 import { UserModule } from '@user/user.module';
+import { CommunityRepository } from '@repository/community.repository';
+import { CommunityModule } from '@community/community.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: ChatList.name, schema: ChatListSchema }]),
     forwardRef(() => ChannelModule),
     UserModule,
+    forwardRef(() => CommunityModule),
   ],
   controllers: [ChatListController],
-  providers: [ChatListService, ChatListRespository, ChannelRepository, UserRepository],
+  providers: [
+    ChatListService,
+    ChatListRespository,
+    ChannelRepository,
+    UserRepository,
+    CommunityRepository,
+  ],
   exports: [MongooseModule],
 })
 export class ChatListModule {}

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -137,21 +137,14 @@ export class ChatListService {
 
     const date = new Date();
 
-    await this.chatListRespository.updateOne(
+    const updatedChatList = await this.chatListRespository.findOneAndUpdate(
       { _id: chatList._id, 'chat.id': +chat_id },
       { $set: { 'chat.$.content': content, 'chat.$.updatedAt': date } },
     );
 
-    const result = {
-      ...chatList.chat[chatNum],
-      content: content,
-      updatedAt: date,
-      channelId: channel_id,
-      communityId: channel.communityId,
-      id: +chat_id,
-    };
+    const result = JSON.parse(JSON.stringify(updatedChatList)).chat[+chat_id];
 
-    return result;
+    return { ...result, communityId: channel.communityId, channelId: channel._id };
   }
 
   async deleteMessage(deleteMessageDto: DeleteMessageDto) {
@@ -174,20 +167,13 @@ export class ChatListService {
 
     const date = new Date();
 
-    await this.chatListRespository.updateOne(
+    const updatedChatList = await this.chatListRespository.findOneAndUpdate(
       { _id: chatList._id, 'chat.id': +chat_id },
       { $set: { 'chat.$.updatedAt': date, 'chat.$.deletedAt': date } },
     );
 
-    const result = {
-      ...chatList.chat[chatNum],
-      updatedAt: date,
-      deletedAt: date,
-      channelId: channel_id,
-      communityId: channel.communityId,
-      id: +chat_id,
-    };
+    const result = JSON.parse(JSON.stringify(updatedChatList)).chat[+chat_id];
 
-    return result;
+    return { ...result, communityId: channel.communityId, channelId: channel._id };
   }
 }

--- a/server/dao/repository/chat-list.respository.ts
+++ b/server/dao/repository/chat-list.respository.ts
@@ -22,4 +22,8 @@ export class ChatListRespository {
   async updateOne(filter, updateField) {
     return await this.chatListModel.updateOne(filter, updateField);
   }
+
+  async findOneAndUpdate(filter, updateField) {
+    return await this.chatListModel.findOneAndUpdate(filter, updateField, { new: true });
+  }
 }


### PR DESCRIPTION
## Issues

- #372 

## 🤷‍♂️ Description

채널 이탈 시 적용이 되지 않는 이슈

## 📷 Screenshots

채널 이탈 후 lastRead 업데이트 하지 못하도록 수정

https://user-images.githubusercontent.com/72093196/207082207-e1e25959-a7d4-4b72-a267-2b808fb3b284.mov



## 📒 Remarks
원인 : 채널 이탈 후 채널에 대해 lastRead 업데이트를 하는 API 호출
해결 : lastRead 업데이트 API 에 채널에 현재 존재하지 않으면 throw 에러 처리

>**이슈 외 커밋**

한 개의 PR에 하나의 로직이 원칙인데 같이 보내게 되었습니다..😇
- accessToken 기간 연장 (15m -> 1hr)
- 커뮤니티 매니저, 채널 매니저도 채팅 삭제 권한을 가진다.