### PR TITLE
[CLIENT] 채널 정보 페이지

### DIFF
--- a/client/src/components/ChannelCard/index.tsx
+++ b/client/src/components/ChannelCard/index.tsx
@@ -1,0 +1,79 @@
+import type { JoinedChannel } from '@apis/channel';
+import type { User } from '@apis/user';
+import type { FC } from 'react';
+
+import Avatar from '@components/Avatar';
+import {
+  CalendarDaysIcon,
+  LinkIcon,
+  LockClosedIcon,
+} from '@heroicons/react/24/solid';
+import { dateStringToKRLocaleDateString } from '@utils/date';
+import cn from 'classnames';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export interface Props {
+  channel: JoinedChannel;
+  manager: User;
+}
+
+const ChannelCard: FC<Props> = ({ channel, manager }) => {
+  const { isPrivate, _id, name, description, createdAt } = channel;
+  const iconContainerClassnames = cn({
+    'bg-label': !isPrivate,
+    'bg-indigo': isPrivate,
+  });
+
+  return (
+    <li className="flex w-[900px] h-[200px] rounded-2xl overflow-hidden shadow hover:translate-x-5 transition-transform">
+      <div
+        className={`flex flex-col justify-center items-center w-[200px] h-full ${iconContainerClassnames}`}
+      >
+        <Link
+          to={`channels/${_id}`}
+          className="h-full w-full flex justify-center items-center [&:hover>svg]:scale-150 "
+        >
+          {isPrivate ? (
+            <LockClosedIcon className="w-16 h-16 fill-offWhite transition-transform" />
+          ) : (
+            <LinkIcon className="w-16 h-16 fill-offWhite transition-transform" />
+          )}
+        </Link>
+      </div>
+
+      <div className="px-4 py-2 w-[80%] break-all bg-offWhite-dark">
+        <div className="text-s22 font-bold mb-2 text-indigo">{name}</div>
+        <div className="text-s16 text-body mb-2">{description}</div>
+        <div className="flex gap-1 items-center py-2">
+          <Avatar
+            size="sm"
+            name={manager.nickname}
+            profileUrl={manager.profileUrl}
+            className="scale-[90%] -translate-x-1"
+          />
+          <span className="text-titleActive">{manager.nickname} (관리자)</span>
+        </div>
+        <div className="flex gap-1 items-center mt-2 text-s14">
+          <div>
+            <span className="sr-only">생성 날짜</span>
+            <CalendarDaysIcon className="w-6 h-6" />
+          </div>
+          <div>
+            {dateStringToKRLocaleDateString(createdAt, {
+              hour: 'numeric',
+              minute: 'numeric',
+            })}
+            에 만들어진{' '}
+            <span className="text-indigo font-bold">
+              {isPrivate && '비공개'}
+            </span>
+            채널입니다.
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+};
+
+export default ChannelCard;

--- a/client/src/components/ChannelName/index.tsx
+++ b/client/src/components/ChannelName/index.tsx
@@ -6,23 +6,41 @@ import React, { memo } from 'react';
 export interface Props extends ComponentPropsWithoutRef<'div'> {
   isPrivate: boolean;
   name: string;
+  size?: 'sm' | 'md' | 'lg';
 }
 
-const ChannelName: FC<Props> = ({ isPrivate, name, ...restProps }) => {
+const nameClassnames = {
+  sm: 'text-s16',
+  md: 'text-s18',
+  lg: 'text-s20',
+};
+
+const iconClassnames = {
+  sm: 'w-5 h-5',
+  md: 'w-6 h-6',
+  lg: 'w-7 h-7',
+};
+
+const ChannelName: FC<Props> = ({
+  isPrivate,
+  name,
+  size = 'sm',
+  ...restProps
+}) => {
   return (
     <div {...restProps}>
       {isPrivate ? (
         <div>
           <span className="sr-only">비공개 채널</span>
-          <LockClosedIcon className="w-5 h-5" />
+          <LockClosedIcon className={iconClassnames[size]} />
         </div>
       ) : (
         <div>
           <span className="sr-only">공개 채널</span>
-          <HashtagIcon className="w-5 h-5" />
+          <HashtagIcon className={iconClassnames[size]} />
         </div>
       )}
-      <div className="text-s16 w-full">{name}</div>
+      <div className={`${nameClassnames[size]} w-full`}>{name}</div>
     </div>
   );
 };

--- a/client/src/components/ChatForm/index.tsx
+++ b/client/src/components/ChatForm/index.tsx
@@ -20,6 +20,8 @@ interface Props extends ComponentPropsWithRef<'textarea'> {
   clear?: boolean;
 }
 
+const maxLength = 300;
+
 const ChatForm: FC<Props> = ({
   editMode = false,
   initialValue = '',
@@ -33,6 +35,8 @@ const ChatForm: FC<Props> = ({
   const [value, onChange, isDirty, setValue] = useInput(initialValue);
   const submitButtonRef = useRef<HTMLButtonElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const exceededMaxLength = value.length >= maxLength;
+  const isSubmittable = isDirty && !exceededMaxLength;
 
   /**
    * 다른 채널로 이동시, value 상태값이 유지되며 채팅 폼이 미리 입력되어 있는 현상을 방지하기 위해
@@ -62,7 +66,7 @@ const ChatForm: FC<Props> = ({
 
   const handleSubmitForm: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
-    if (!value.trim() || !isDirty) return;
+    if (!value.trim() || !isSubmittable) return;
 
     handleSubmitChat?.(value, e);
     setValue(initialValue);
@@ -99,6 +103,7 @@ const ChatForm: FC<Props> = ({
         spellCheck={false}
         {...restProps}
         onKeyDown={handleKeyDown}
+        maxLength={maxLength}
         value={value}
         ref={textareaRef}
         onChange={onChange}
@@ -119,7 +124,7 @@ const ChatForm: FC<Props> = ({
         <button
           className="chat-submit-button absolute right-3 h-full [&:hover>svg]:fill-indigo "
           ref={submitButtonRef}
-          disabled={!isDirty}
+          disabled={!isDirty || exceededMaxLength}
         >
           <span className="sr-only">채팅 입력 버튼</span>
           <PaperAirplaneIcon className="w-6 h-6" />

--- a/client/src/layouts/ChannelInfoLayer/index.tsx
+++ b/client/src/layouts/ChannelInfoLayer/index.tsx
@@ -1,0 +1,64 @@
+import ChannelCard from '@components/ChannelCard';
+import ErrorIcon from '@components/ErrorIcon';
+import ErrorMessage from '@components/ErrorMessage';
+import Spinner from '@components/Spinner';
+import { useCommunitiesMapQueryData } from '@hooks/community';
+import { useCommunityUsersMapQuery } from '@hooks/user';
+import React from 'react';
+import Scrollbars from 'react-custom-scrollbars-2';
+import { useParams } from 'react-router-dom';
+
+const ChannelInfoLayer = () => {
+  const { communityId } = useParams() as { communityId: string };
+  const communitiesMapQueryData = useCommunitiesMapQueryData();
+  const communitySummary = communitiesMapQueryData?.[communityId];
+  const communityUsersMapQuery = useCommunityUsersMapQuery(communityId);
+
+  const isLoading = !communitySummary || communityUsersMapQuery.isLoading;
+  const isError = communityUsersMapQuery.isError;
+
+  if (isError) {
+    return (
+      <div className="flex flex-col w-full h-full flex justify-center items-center">
+        <ErrorIcon />
+        <ErrorMessage size="lg">
+          사용자 정보를 불러오는 중에 오류가 발생했습니다.
+        </ErrorMessage>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="w-full h-full flex justify-center items-center">
+        <Spinner />
+        채널 정보를 불러오는 중입니다...
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full p-8">
+      <Scrollbars>
+        <ol className="flex flex-col justify-center gap-8">
+          {communitySummary.channels.map((channel) => {
+            const manager =
+              process.env.NODE_ENV === 'development'
+                ? Object.values(communityUsersMapQuery.data)[0]
+                : communityUsersMapQuery.data[channel.managerId];
+
+            return (
+              <ChannelCard
+                key={channel._id}
+                channel={channel}
+                manager={manager}
+              />
+            );
+          })}
+        </ol>
+      </Scrollbars>
+    </div>
+  );
+};
+
+export default ChannelInfoLayer;

--- a/client/src/layouts/SocketLayer/index.tsx
+++ b/client/src/layouts/SocketLayer/index.tsx
@@ -1,4 +1,3 @@
-import type { CommunitySummaries } from '@apis/community';
 import type {
   ReceiveNewChatListener,
   ReceiveEditedChatListener,
@@ -11,6 +10,7 @@ import REGEX from '@constants/regex';
 import { useMyInfoQueryData } from '@hooks/auth';
 import { useSetChannelQueryData } from '@hooks/channel';
 import { useSetChatsQueryData } from '@hooks/chat';
+import { useCommunitiesQuery } from '@hooks/community';
 import ClientIO from '@sockets/ClientIO';
 import { SOCKET_EVENTS } from '@sockets/ClientIOTypes';
 import { useRootStore } from '@stores/rootStore';
@@ -18,7 +18,6 @@ import { useSocketStore } from '@stores/socketStore';
 import { useTokenStore } from '@stores/tokenStore';
 import { isScrollTouchedBottom } from '@utils/scrollValues';
 import React, { useEffect, useMemo, useRef } from 'react';
-import { useLoaderData } from 'react-router-dom';
 
 const SocketLayer = () => {
   const myInfo = useMyInfoQueryData();
@@ -27,7 +26,8 @@ const SocketLayer = () => {
   const sockets = useSocketStore((state) => state.sockets);
   const setSockets = useSocketStore((state) => state.setSockets);
   const socketArr = useMemo(() => Object.values(sockets), [sockets]);
-  const communitySummaries = useLoaderData() as CommunitySummaries;
+  const communitySummariesQuery = useCommunitiesQuery();
+  const communitySummaries = communitySummariesQuery.data ?? [];
   const communityIds = useMemo(
     () => communitySummaries.map((communitySummary) => communitySummary._id),
     [communitySummaries],

--- a/client/src/mocks/handlers/Channel.js
+++ b/client/src/mocks/handlers/Channel.js
@@ -52,6 +52,7 @@ const CreateChannel = rest.post(
       description,
       existUnreadChat: false,
       type,
+      createdAt: new Date().toISOString(),
       users: [me._id],
     };
 
@@ -72,7 +73,6 @@ const CreateChannel = rest.post(
 
 const leaveChannelEndPoint = API_URL + endPoint.leaveChannel(':channelId');
 const LeaveChannel = rest.delete(leaveChannelEndPoint, (req, res, ctx) => {
-  const { channelId } = req.params;
   const ERROR = false;
 
   const errorResponse = res(...createErrorContext(ctx));

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -1,5 +1,6 @@
 import type { User } from '@apis/user';
 
+import ChannelName from '@components/ChannelName';
 import ChatForm from '@components/ChatForm';
 import ChatList from '@components/ChatList';
 import Spinner from '@components/Spinner';
@@ -156,7 +157,14 @@ const Channel = () => {
     <div className="w-full h-full flex flex-col">
       <header className="flex items-center pl-[56px] w-full border-b border-line shrink-0 basis-[90px]">
         <div className="block w-[400px] overflow-ellipsis overflow-hidden whitespace-nowrap text-indigo font-bold text-[24px]">
-          {channelWithUsersMap.data && `#${channelWithUsersMap.data.name}`}
+          {channelWithUsersMap.data && (
+            <ChannelName
+              className="flex gap-2 items-center"
+              name={channelWithUsersMap.data.name}
+              isPrivate={channelWithUsersMap.data.isPrivate}
+              size="lg"
+            />
+          )}
         </div>
       </header>
       <div className="flex h-full">

--- a/client/src/pages/Community/index.tsx
+++ b/client/src/pages/Community/index.tsx
@@ -1,3 +1,4 @@
+import ChannelInfoLayer from '@layouts/ChannelInfoLayer';
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
@@ -5,6 +6,7 @@ const Community = () => {
   return (
     <main className="flex flex-col flex-1">
       <Outlet />
+      <ChannelInfoLayer />
     </main>
   );
 };

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -26,7 +26,10 @@ module.exports = {
       line: '#D9DBE9',
       inputBackground: '#EFF0F6',
       background: '#F7F7FC;',
-      offWhite: '#FEFEFE',
+      offWhite: {
+        DEFAULT: '#FEFEFE',
+        dark: '#12121208',
+      },
       indigo: '#1D1D50',
       primary: {
         DEFAULT: '#FFA52D',


### PR DESCRIPTION
## Issues
- #375 

## 🤷‍♂️ Description

채널 정보 페이지 (커뮤니티 입장시 보이는 페이지)

## 📝 Primary Commits

- [X] 채팅 폼의 최대 글자수를 제한 (300자)
- [X] 커뮤니티 생성시 namespace 소켓 등록 안되는 오류 수정
- [X] 채널 제목 표시부분에 비공개여부에 따라 다른 아이콘 표시
- [X] 채널 생성시 mock data response에 createdAt누락된것 추가
- [X] ChannelInfoLayer 추가
- [X] ChannelCard 추가


## 📷 Screenshots

 
![채널정보](https://user-images.githubusercontent.com/79135734/207085152-4bc36c9f-e24b-4458-872f-7150b921fb74.gif)

 