### PR TITLE
fix: 채널 이탈 이슈 해결 #372

### DIFF
--- a/server/apps/api/src/channel/channel.service.ts
+++ b/server/apps/api/src/channel/channel.service.ts
@@ -167,8 +167,12 @@ export class ChannelService {
 
   async updateLastRead(updateLastReadDto: UpdateLastReadDto) {
     const { community_id, channel_id, requestUserId } = updateLastReadDto;
-    const channel = await this.channelRepository.findOne({ _id: channel_id, deletedAt: undefined });
-    if (!channel) throw new BadRequestException('존재하지 않는 채널입니다.');
+    const channel = await this.channelRepository.findOne({
+      _id: channel_id,
+      deletedAt: undefined,
+      users: requestUserId,
+    });
+    if (!channel) throw new BadRequestException('사용자가 존재하는 채널이 아닙니다.');
 
     // 유저 도큐먼트의 커뮤니티:채널 필드 업데이트
     await this.userRepository.updateObject(


### PR DESCRIPTION
## Issues

- #372 

## 🤷‍♂️ Description

채널 이탈 시 적용이 되지 않는 이슈

## 📷 Screenshots

채널 이탈 후 lastRead 업데이트 하지 못하도록 수정

https://user-images.githubusercontent.com/72093196/207082207-e1e25959-a7d4-4b72-a267-2b808fb3b284.mov



## 📒 Remarks
원인 : 채널 이탈 후 채널에 대해 lastRead 업데이트를 하는 API 호출
해결 : lastRead 업데이트 API 에 채널에 현재 존재하지 않으면 throw 에러 처리
