### PR TITLE
[CLIENT] 안 읽은 메시지 버그 수정

### DIFF
--- a/client/src/components/ChatList/index.tsx
+++ b/client/src/components/ChatList/index.tsx
@@ -5,6 +5,7 @@ import type { FC } from 'react';
 import ChatItem from '@components/ChatItem';
 import {
   useSetUnreadChatIdQueryData,
+  useUnreadChatIdQuery,
   useUnreadChatIdQueryData,
 } from '@hooks/chat';
 import useIntersectionObservable from '@hooks/useIntersectionObservable';
@@ -16,6 +17,7 @@ interface Props {
   users: UsersMap;
   communityManagerId?: string;
   channelManagerId?: string;
+  unreadChatId: number;
 }
 
 const ChatList: FC<Props> = ({
@@ -23,6 +25,7 @@ const ChatList: FC<Props> = ({
   users,
   communityManagerId,
   channelManagerId,
+  unreadChatId,
 }) => {
   const params = useParams();
   const channelId = params.roomId as string;
@@ -36,10 +39,10 @@ const ChatList: FC<Props> = ({
     },
   );
 
-  // 캐시에 있는 안 읽은 메시지의 id를 가져온다.
+  // 현재 캐시에 저장된 안 읽은 메시지의 id를 가져온다.
   const cachedUnreadChatId = useUnreadChatIdQueryData(channelId) as number;
-  // 채널 입장 시의 캐시에 저장되어있는 안 읽은 메시지의 id를 저장한다.
-  const firstUnreadChatId = useRef(cachedUnreadChatId);
+  // 채널 입장 시의 안 읽은 메시지의 id를 저장한다.
+  const firstUnreadChatId = useRef(unreadChatId);
 
   return (
     <>
@@ -49,17 +52,14 @@ const ChatList: FC<Props> = ({
             <Fragment key={page.chat[0].id}>
               {page.chat.map((chat) => (
                 <Fragment key={chat.id}>
-                  {/* chat의 id가 첫 렌더링 시의 캐시에 저장된 안 읽은 메시지의 id와 같다면 divider를 렌더링한다.
-                  최신 캐시에 있는 안 읽은 메시지의 id와 비교하지 않으므로 해당 값이 -1로 바뀌어도
-                  divider는 사라지지 않는다.
-                  */}
+                  {/* 채널 입장 시의 안 읽은 메시지의 id와 chat.id가 같다면 divider를 띄운다 */}
                   {chat.id === firstUnreadChatId.current && (
                     <div
                       className="flex items-center relative h-0 my-3 border-b-[1px] border-error"
                       ref={
                         /* 캐시에 저장된 안 읽은 메시지의 id가 -1이 되면 divider에 더이상
                         observable ref가 붙지 않도록 한다*/
-                        chat.id === cachedUnreadChatId
+                        cachedUnreadChatId !== -1
                           ? firstUnreadChatObservable
                           : null
                       }

--- a/client/src/hooks/chat.ts
+++ b/client/src/hooks/chat.ts
@@ -450,6 +450,9 @@ export const useUnreadChatIdQuery = (channelId: string) => {
   const query = useQuery<GetUnreadChatIdResult['unreadChatId'], AxiosError>(
     key,
     () => getUnreadChatId(channelId),
+    {
+      cacheTime: 0,
+    },
   );
 
   return query;

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -194,14 +194,17 @@ const Channel = () => {
           >
             <div ref={intersectionObservable} />
             <ul className="flex flex-col gap-3 [&>*:hover]:bg-background pt-7">
-              {chatsInfiniteQuery.data && channelWithUsersMap.data && (
-                <ChatList
-                  communityManagerId={communityManagerId}
-                  channelManagerId={channelManagerId}
-                  pages={chatsInfiniteQuery.data.pages}
-                  users={channelWithUsersMap.data.users}
-                />
-              )}
+              {chatsInfiniteQuery.data &&
+                channelWithUsersMap.data &&
+                unreadChatIdQuery.data && (
+                  <ChatList
+                    communityManagerId={communityManagerId}
+                    channelManagerId={channelManagerId}
+                    pages={chatsInfiniteQuery.data.pages}
+                    users={channelWithUsersMap.data.users}
+                    unreadChatId={unreadChatIdQuery.data}
+                  />
+                )}
             </ul>
           </Scrollbars>
           <ChatForm


### PR DESCRIPTION
## Issues
- #369 

## 이유
1. A 채널 페이지를 본다. 채널에 입장했으므로 unreadChatId 쿼리는 -1이 된다.
2. 다른 채널 페이지로 간다. A 채널 페이지에 대한 unreadChatId 쿼리는 inactive가 되며 캐시에 -1이 저장된다.
3. A 채널 페이지에 새로운 메시지가 들어오고 사용자는 A 채널 페이지로 간다. 이때 캐시에는 -1이 저장되어있으므로 우선은 해당 값이 ref에 들어간다. 
4. unreadChatId를 `n`으로 fetch해 온 후 캐시를 업데이트하나 ref.current는 변경되지 않으므로 `n`에 해당하는 `<ChatItem />`위에 new divider가 붙지 않는다.

## 해결
1. unreadChatId 쿼리의 cacheTime을 0으로 주어 채널 페이지를 벗어나면 = 즉 unreadChatId 쿼리가 inactive된 후 지워지도록 한다.
2. 따라서 채널 페이지에 접속할 때마다 새로운 unreadChatId를 fetch해오도록 한다.
6. 채널 페이지에서 unreadChatId를 fetch해와 -1이 아니면 위에 새로운 메시지가 있다고 표시한다.
7. 채널 페이지가 이 unreadChatId를 ChatList에 내려주어 ref에 해당 id를 저장하도록 한다.

## 현재 있는 버그들
1. 채널 페이지 입장시 스크롤바가 최하단으로 내려가지 않는 문제
2. 새로운 메시지가 있으나 unreadChatId가 -1로 오는 문제