### PR TITLE
[Server/community] 안읽은 채팅 존재 여부 확인 못하는 이슈  해결

### DIFF
--- a/server/apps/api/src/community/community.service.ts
+++ b/server/apps/api/src/community/community.service.ts
@@ -56,11 +56,9 @@ export class CommunityService {
             const channelInfo = getChannelBasicInfo(channel);
             // 안읽은 채팅 있는 지 확인
             const lastChatList = await this.chatListRepository.findById(channel.chatLists.at(-1));
-
             const lastChatTime = lastChatList.chat.at(-1).get('createdAt');
 
-            channelInfo['existUnreadChat'] =
-              new Date(channels.get(channelId).getTime()) <= lastChatTime;
+            channelInfo['existUnreadChat'] = channels.get(channelId).getTime() <= lastChatTime;
             channelsInfo.push(channelInfo);
           }),
         );

--- a/server/apps/api/src/community/community.service.ts
+++ b/server/apps/api/src/community/community.service.ts
@@ -57,9 +57,10 @@ export class CommunityService {
             // 안읽은 채팅 있는 지 확인
             const lastChatList = await this.chatListRepository.findById(channel.chatLists.at(-1));
 
-            const lastChatTime = lastChatList.chat.at(-1).createdAt;
+            const lastChatTime = lastChatList.chat.at(-1).get('createdAt');
+
             channelInfo['existUnreadChat'] =
-              channels.get(channelId).getTime() <= new Date(lastChatTime).getTime();
+              new Date(channels.get(channelId).getTime()) <= lastChatTime;
             channelsInfo.push(channelInfo);
           }),
         );


### PR DESCRIPTION
## 🤷‍♂️ Description

문제 : 사용자의 안읽은 채팅 존재 여부를 확인할 수 없는 이슈
원인 : #332 PR에서 코드를 잘 못 수정해서 비교하는 값이 null이 되었음 (편의상 JSON으로 처리한 것을 Map으로 바꾸면서 에러 발생)
해결 : null이 되는 이유를 찾고 코드 수정

