### PR TITLE
[CLIENT] 안읽은메세지 버그 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,6 @@ import Root from '@pages/Root';
 import SignIn from '@pages/SignIn';
 import SignUp from '@pages/SignUp';
 import UnAuthorizedLayer from '@pages/UnAuthorizedLayer';
-import communitiesLoader from '@routes/communitiesLoader';
 import HomeErrorElement from '@routes/HomeErrorElement';
 import React from 'react';
 import {
@@ -26,18 +25,12 @@ import {
   Outlet,
 } from 'react-router-dom';
 
-import queryClient from './queryClient';
-
 const router = createBrowserRouter(
   createRoutesFromElements(
     <Route>
       <Route path="/" element={<Root />} />
       <Route element={<AuthorizedLayer />}>
-        <Route
-          element={<Home />}
-          loader={communitiesLoader(queryClient)}
-          errorElement={<HomeErrorElement />}
-        >
+        <Route element={<Home />} errorElement={<HomeErrorElement />}>
           <Route path="dms" element={<DM />}>
             <Route index element={<Friends />} />
             <Route

--- a/client/src/constants/user.ts
+++ b/client/src/constants/user.ts
@@ -6,12 +6,16 @@ export const USER_STATUS = {
 
 export const ASNITY_DEVELOPER: Record<string, string> = {
   default: 'https://cdn-icons-png.flaticon.com/512/1946/1946429.png',
-  'a@asnity.com':
+  // 준영
+  'q@asnity.com':
     'https://user-images.githubusercontent.com/79135734/207336121-5c984a8a-40d3-404b-ae8e-32b1e474014e.jpg',
+  // 나영
   'w@asnity.com':
     'https://user-images.githubusercontent.com/79135734/207336712-c40b1343-8110-4d50-bc53-55782ef51fba.png',
+  // 수만
   'e@asnity.com':
     'https://user-images.githubusercontent.com/72093196/207337464-cc135ea2-738d-4f20-b64e-c7c9935ed0b5.png',
+  // 민종
   'r@asnity.com':
     'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSKe5YqD_avOk-6bk5y_Ag9zx4r3qlCj0q1lg&usqp=CAU',
   'pepe@pepe.com':

--- a/client/src/hooks/combine.ts
+++ b/client/src/hooks/combine.ts
@@ -1,0 +1,44 @@
+import { getCommunities } from '@apis/community';
+import REGEX from '@constants/regex';
+import { useUpdateLastReadMutation } from '@hooks/channel';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import queryKeyCreator from '@/queryKeyCreator';
+
+/**
+ * 10초마다 커뮤니티 목록을 불러옵니다. 채널에 입장해있다면 해당 채널의 lastRead를 업데이트한 뒤에 불러옵니다.
+ */
+export const useUpdateLastReadAndFetchCommunitiesIntervalEffect = (
+  refetchInterval: number = 1000 * 10,
+) => {
+  const queryClient = useQueryClient();
+  const updateLastReadMutation = useUpdateLastReadMutation();
+  const key = queryKeyCreator.community.list();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const groups = window.location.pathname.match(REGEX.CHANNEL)?.groups as {
+        communityId?: string;
+        roomId?: string;
+      };
+
+      if (groups?.communityId && groups?.roomId) {
+        updateLastReadMutation
+          .mutateAsync({
+            communityId: groups.communityId,
+            channelId: groups.roomId,
+          })
+          .catch((error) => console.error(error)) // 여기의 에러는 로깅만. 커뮤니티 목록을 불러오는게 끊기면 안됩니다.
+          .finally(() => {
+            queryClient.fetchQuery(key, getCommunities);
+          });
+        return;
+      }
+
+      queryClient.fetchQuery(key, getCommunities);
+    }, refetchInterval);
+
+    return () => clearInterval(interval);
+  }, []);
+};

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -25,8 +25,8 @@ import queryKeyCreator from 'src/queryKeyCreator';
 export const useCommunitiesQuery = () => {
   const key = queryKeyCreator.community.list();
   const query = useQuery<CommunitySummaries, AxiosError>(key, getCommunities, {
-    refetchInterval: 1000 * 10,
     staleTime: 1000 * 10,
+    cacheTime: 1000 * 10,
   });
 
   return query;

--- a/client/src/hooks/community.ts
+++ b/client/src/hooks/community.ts
@@ -22,6 +22,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import queryKeyCreator from 'src/queryKeyCreator';
 
+/**
+ * - 커뮤니티 목록을 가져옵니다.
+ * - `refetchInterval`을 바꾸면 안됩니다.
+ * - @hooks/combine.ts - useUpdateLastReadAndFetchCommunitiesIntervalEffect 참고
+ * - \**#388** (https://github.com/boostcampwm-2022/web24-Asnity/pull/388)
+ */
 export const useCommunitiesQuery = () => {
   const key = queryKeyCreator.community.list();
   const query = useQuery<CommunitySummaries, AxiosError>(key, getCommunities, {

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -1,5 +1,11 @@
+import Button from '@components/Button';
+import ErrorIcon from '@components/ErrorIcon';
+import ErrorMessage from '@components/ErrorMessage';
+import FullScreenSpinner from '@components/FullScreenSpinner';
 import CommonModal from '@components/Modals/CommonModal';
 import ContextMenuModal from '@components/Modals/ContextMenuModal';
+import { useUpdateLastReadAndFetchCommunitiesIntervalEffect } from '@hooks/combine';
+import { useCommunitiesQuery } from '@hooks/community';
 import Gnb from '@layouts/Gnb';
 import Sidebar from '@layouts/Sidebar';
 import Sockets from '@layouts/SocketLayer';
@@ -7,6 +13,32 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 
 const Home = () => {
+  useUpdateLastReadAndFetchCommunitiesIntervalEffect(1000 * 10);
+  const communitiesQuery = useCommunitiesQuery();
+
+  if (communitiesQuery.isError) {
+    return (
+      <div className="flex flex-col w-screen h-screen items-center justify-center">
+        <ErrorIcon />
+        <ErrorMessage size="lg" className="mb-3">
+          커뮤니티 목록을 불러오는 중, 오류가 발생했습니다. 새로고침을 해주세요.
+        </ErrorMessage>
+        <Button
+          size="md"
+          color="error"
+          onClick={() => window.location.reload()}
+          type="button"
+        >
+          새로고침
+        </Button>
+      </div>
+    );
+  }
+
+  if (communitiesQuery.isLoading) {
+    return <FullScreenSpinner />;
+  }
+
   return (
     <div className="wrapper flex flex-1">
       <Sockets />


### PR DESCRIPTION
## 🤷‍♂️ Description

- 일정 간격으로 `communities` 불러오는데, 채널 입장과 퇴장시에만 `lastRead`를 업데이트하기 때문에, 채널에 머무르고 있을 때는 `lastRead`보다 그 사이에 전송된 채팅들의 `createdAt`이 앞서나가서, `communities`를 불러올 때, 보고있는 채널에도 new message가 표시되는 문제
- 일정 간격으로 `communities`불러오기 전에 `lastRead`업데이트 한 뒤에 불러오는 이펙트함수 추가
- 더 이상 내가 입장한 채널에서는 new 메세지가 보이지 않습니다. (new 정보를 불러오기 전에, 채널에 입장해있다면 무조건 lastRead를 업데이트하기 때문에)

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `useUpdateLastReadAndFetchCommunitiesIntervalEffect` 구현

 