### PR TITLE
[Hotfix] git attributes 파일 최 상위로 이동

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/server/artillery linguist-vendored=false

--- a/server/.gitattributes
+++ b/server/.gitattributes
@@ -1,1 +1,0 @@
-/artillery linguist-vendored=false


### PR DESCRIPTION
git attributes 파일 최 상위로 이동해야 languages 설정이 작동하여 변경했습니다.