### PR TITLE
[Server/chat] 안 읽은 채팅 이슈 해결

### DIFF
--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -113,10 +113,8 @@ export class ChatListService {
         R = M - 1;
       }
     }
-    if (new Date(unreadChatList[M].createdAt) < lastRead) {
-      return NOT_EXIST_UNREAD_CHAT;
-    }
-    return unreadChatList[M].id;
+
+    return L >= unreadChatList.length ? NOT_EXIST_UNREAD_CHAT : L;
   }
 
   async modifyMessage(modifyMessageDto: ModifyMessageDto) {

--- a/server/apps/api/src/chat-list/chat-list.service.ts
+++ b/server/apps/api/src/chat-list/chat-list.service.ts
@@ -114,7 +114,7 @@ export class ChatListService {
       }
     }
 
-    return L >= unreadChatList.length ? NOT_EXIST_UNREAD_CHAT : L;
+    return L >= unreadChatList.length ? NOT_EXIST_UNREAD_CHAT : unreadChatList[L].id;
   }
 
   async modifyMessage(modifyMessageDto: ModifyMessageDto) {


### PR DESCRIPTION
## Issues
- #415 
## 🤷‍♂️ Description

안 읽은 채팅이 있음에도 채팅 위치가 받아와지지 않는 이슈 해결

안 읽은 채팅을 찾는 로직을 수정하였습니다.

## 📷 Screenshots
>**테스트 환경**

POST MAN을 사용
```tsx
pm.test("안 읽은 위치", () => {
    pm.expect(pm.response.json().result.unreadChatId).equal(215);   // 215는 고정된 안 읽은 채팅 위치
})
```
채널 마지막 방문 시간을 업데이트 하지 않아 채널의 안 읽은 채팅 위치는 215로 고정되어야 함.
`채팅 저장 -> 안 읽은 위치가 215인지 확인` 과정을 100번 반복함

>**수정 전**
<img width="804" alt="스크린샷 2023-01-02 오후 5 40 58" src="https://user-images.githubusercontent.com/72093196/210209363-97652be0-6ee2-454e-963e-47137414d334.png">

>**수정 후**
<img width="804" alt="스크린샷 2023-01-02 오후 5 41 43" src="https://user-images.githubusercontent.com/72093196/210209412-0de831e4-ce47-4a43-aee6-48fcb91ea19c.png">

 
## 📒 Remarks
### 수정 전 코드
```tsx
getUnreadChatId(unreadChatList, lastRead) {
    let L = 0;
    let R = unreadChatList.length - 1;
    let M;
    while (L <= R) {
      M = Math.floor((L + R) / 2);
      if (new Date(unreadChatList[M].createdAt) < lastRead) {
        L = M + 1;
      } else {
        R = M - 1;
      }
    }
    if (new Date(unreadChatList[M].createdAt) < lastRead) {
      return NOT_EXIST_UNREAD_CHAT;
    }
    return unreadChatList[M].id;
  }
```
>**버그가 발생하는 예시**

- 0 1 2 3 4 5 6 7 8 총 9개의 채팅이 있을 경우
- 마지막으로 채널에 접속한 시간은 채팅5와 채팅6 사이 시간
- 기대하는 값 : 안 읽은 채팅 인덱스 = 6
1. L=0, R=8 -> M=4 -> L = 5
2. L=5, R=8 -> M=6 -> R = 5
3. L=5, R=5 -> M=5 -> L = 6
4. L>R -> M = 5
new Date(unreadChatList[M].createdAt) < lastRead 임으로 NOT_EXIST_UNREAD_CHAT 반환

### 수정 후 코드
```tsx
  getUnreadChatId(unreadChatList, lastRead) {
    let L = 0;
    let R = unreadChatList.length - 1;
    let M;
    while (L <= R) {
      M = Math.floor((L + R) / 2);
      if (new Date(unreadChatList[M].createdAt) < lastRead) {
        L = M + 1;
      } else {
        R = M - 1;
      }
    }
    return L >= unreadChatList.length ? NOT_EXIST_UNREAD_CHAT : unreadChatList[L].id;
  }
```
L은 lastRead보다 큰 값중에 가장 작은 값의 인덱스가 된다.
L이 chatList 길이를 넘어갈 경우 안 읽은 채팅 없음(NOT_EXIST_UNREAD_CHAT)을 반환하고 그렇지 않으면 unreadChatList[L].id를 반환한다.