### PR TITLE
[Server/Feature] 이전 Chats 사전 Caching

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -50,7 +50,7 @@ jobs:
 #          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ASUMI_URL }}
 #        if: always()
   build_socket:
-    if: ${{ github.event.pull_request.merged == true  && ( contains(github.ref, 'dev-be') || contains(github.ref, 'main') ) }}
+    if: ${{ github.event.pull_request.merged == true  && ( contains(github.ref, 'dev-be') || contains(github.ref, 'main') || contains(github.ref, 'dev-ny')) }}
     runs-on: ubuntu-latest
     steps:
       - name: 체크아웃

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build_api:
-    if: ${{ github.event.pull_request.merged == true  && ( contains(github.ref, 'dev-be') || contains(github.ref, 'main') ) }}
+    if: ${{ github.event.pull_request.merged == true  && ( contains(github.ref, 'dev-be') || contains(github.ref, 'main') || contains(github.ref, 'dev-ny')) }}
     runs-on: ubuntu-latest
     steps:
       - name: 체크아웃
@@ -120,7 +120,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FAIL_WEBHOOK_URL }}
         if: failure()
   nCloudDeploy:
-    if: ${{ github.event.pull_request.merged == true  && ( contains(github.ref, 'dev-be') || contains(github.ref, 'main') ) }}
+    if: ${{ github.event.pull_request.merged == true  && ( contains(github.ref, 'dev-be') || contains(github.ref, 'main') || contains(github.ref, 'dev-ny') ) }}
     needs: [build_api, build_socket]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main", "dev","dev-be" ]
     paths: 'server/**'
   pull_request:
-    branches: [ "main", "dev","dev-be" ]
+    branches: [ "main", "dev","dev-be","dev-ny" ]
     paths: 'server/**'
     types:
       - closed

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -40,15 +40,15 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/asnity-api:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Slack Merge bot 실행
-        uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          author_name: Backend dev PR merge!
-          fields: repo,commit,message,author
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ASUMI_URL }}
-        if: always()
+#      - name: Slack Merge bot 실행
+#        uses: 8398a7/action-slack@v3
+#        with:
+#          status: ${{ job.status }}
+#          author_name: Backend dev PR merge!
+#          fields: repo,commit,message,author
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ASUMI_URL }}
+#        if: always()
   build_socket:
     if: ${{ github.event.pull_request.merged == true  && ( contains(github.ref, 'dev-be') || contains(github.ref, 'main') ) }}
     runs-on: ubuntu-latest

--- a/server/__mock__/user.mock.ts
+++ b/server/__mock__/user.mock.ts
@@ -1,6 +1,5 @@
 import { ObjectId } from 'bson';
-import { FollowerDto } from '@user/dto/follower.dto';
-// _id: new ObjectId('63734af9e62b37012c73e399'),
+
 export const initTestUser1 = {
   name: '',
   _id: new ObjectId('63734e98384f478a32c3a1cc'),
@@ -14,11 +13,6 @@ export const initTestUser2 = {
   id: 'test_asmi@naver.com',
   password: '12341234',
   nickname: 'asmi',
-};
-
-export const followerDtoMock: FollowerDto = {
-  myId: '63734af9e62b37012c73e399',
-  followId: '63734e98384f478a32c3a1cc',
 };
 
 export const user1Modify = {

--- a/server/apps/api/src/community/community.service.ts
+++ b/server/apps/api/src/community/community.service.ts
@@ -36,7 +36,7 @@ export class CommunityService {
     const communitiesInfo = await Promise.all(
       Array.from(user.communities.values()).map(async (userCommunity) => {
         const { _id, channels } = userCommunity as communityInUser;
-        const community = await this.communityRepository.findByIdAfterCache(_id);
+        const community = await this.communityRepository.findById(_id);
         this.verifyChannelInCommunity(community, channels);
         const channelsInfo = await Promise.all(
           Array.from(channels.keys()).map(async (channelId) => {
@@ -63,7 +63,7 @@ export class CommunityService {
   async appendUsersToCommunity(appendUsersToCommunityDto: AppendUsersToCommunityDto) {
     const { community_id, requestUserId, users } = appendUsersToCommunityDto;
     const communityId = community_id;
-    const user = await this.userRepository.findById(appendUsersToCommunityDto.requestUserId);
+    const user = await this.userRepository.findById(requestUserId);
     if (!IsUserInCommunity(user, communityId)) {
       throw new BadRequestException(`커뮤니티에 속하지 않는 사용자는 요청할 수 없습니다.`);
     }

--- a/server/apps/api/src/user/dto/follower.dto.ts
+++ b/server/apps/api/src/user/dto/follower.dto.ts
@@ -1,9 +1,11 @@
-import { IsString } from 'class-validator';
+import { IsMongoId, IsNotEmpty } from 'class-validator';
 
 export class FollowerDto {
-  @IsString()
-  myId: string;
+  @IsNotEmpty()
+  @IsMongoId()
+  requestUserId: string;
 
-  @IsString()
+  @IsNotEmpty()
+  @IsMongoId()
   followId: string;
 }

--- a/server/apps/api/src/user/dto/get-users.dto.ts
+++ b/server/apps/api/src/user/dto/get-users.dto.ts
@@ -1,0 +1,11 @@
+import { IsMongoId, IsNotEmpty, IsString } from 'class-validator';
+
+export class GetUsersDto {
+  @IsNotEmpty()
+  @IsString()
+  id: string;
+
+  @IsNotEmpty()
+  @IsMongoId()
+  requestUserId: string;
+}

--- a/server/apps/api/src/user/dto/modify-user.dto.ts
+++ b/server/apps/api/src/user/dto/modify-user.dto.ts
@@ -1,20 +1,10 @@
-import {
-  IsEmail,
-  IsIn,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-  Length,
-  Min,
-  MinLength,
-} from 'class-validator';
-import { PROVIDER, STATUS } from '@utils/def';
-import { Prop } from '@nestjs/mongoose';
+import { IsIn, IsMongoId, IsNotEmpty, IsOptional, IsString, Length } from 'class-validator';
+import { STATUS } from '@utils/def';
 
 export class ModifyUserDto {
-  @IsOptional()
-  @IsString()
-  _id: string;
+  @IsNotEmpty()
+  @IsMongoId()
+  requestUserId: string;
 
   @IsOptional()
   @IsString()

--- a/server/apps/api/src/user/helper/checkRelation.ts
+++ b/server/apps/api/src/user/helper/checkRelation.ts
@@ -3,7 +3,7 @@ import { RELATION } from './Relation';
 
 export const checkRelation = (myFollowings, yourFollowers, followerDto) => {
   const isAlreadyFollow = myFollowings.includes(followerDto.followId);
-  const isAlreadyFollowAtOther = yourFollowers.includes(followerDto.myId);
+  const isAlreadyFollowAtOther = yourFollowers.includes(followerDto.requestUserId);
   if (!isAlreadyFollow && isAlreadyFollowAtOther) {
     throw new ConflictException('갱신 이상! (팔로우 안되어있으나, 상대방에겐 내가 팔로우됨)');
   } else if (isAlreadyFollow && !isAlreadyFollowAtOther) {

--- a/server/apps/api/src/user/user.controller.ts
+++ b/server/apps/api/src/user/user.controller.ts
@@ -1,19 +1,17 @@
-import { Body, Controller, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { UserService } from './user.service';
 import { JwtAccessGuard } from '@api/src/auth/guard';
 import { FollowerDto, ModifyUserDto } from './dto';
-import { ObjectIdValidationPipe } from '@custom/pipe/mongodbObjectIdValidation.pipe';
 import { RELATION } from '@user/helper/Relation';
+import { ReceivedData } from '@custom/decorator/ReceivedData.decorator';
 
 @Controller('api/user')
 export class UserController {
   constructor(private userService: UserService) {}
 
-  @Post('following/:id')
+  @Post('following/:followId')
   @UseGuards(JwtAccessGuard)
-  async addFollowing(@Param('id', ObjectIdValidationPipe) id: string, @Req() req: any) {
-    const myId = req.user._id;
-    const addFollowingDto: FollowerDto = { myId, followId: id };
+  async addFollowing(@ReceivedData() addFollowingDto: FollowerDto) {
     const result = await this.userService.toggleFollowing(addFollowingDto);
     return result;
   }
@@ -36,9 +34,8 @@ export class UserController {
 
   @Patch('settings')
   @UseGuards(JwtAccessGuard)
-  async modifyUserSetting(@Body() modifyUserDto: ModifyUserDto, @Req() req: any) {
-    const _id = req.user._id;
-    await this.userService.modifyUser({ ...modifyUserDto, _id });
+  async modifyUserSetting(@ReceivedData() modifyUserDto: ModifyUserDto) {
+    await this.userService.modifyUser(modifyUserDto);
     return { message: '사용자 정보 변경 완료' };
   }
 }

--- a/server/apps/api/src/user/user.service.ts
+++ b/server/apps/api/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, ConflictException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { UserRepository } from '@repository/user.repository';
 import { FollowerDto, ModifyUserDto } from './dto';
 import { getUserBasicInfo } from '@user/helper/getUserBasicInfo';
@@ -10,7 +10,7 @@ export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
   async toggleFollowing(followerDto: FollowerDto) {
-    const user = await this.userRepository.findById(followerDto.myId);
+    const user = await this.userRepository.findById(followerDto.requestUserId);
     const otherUser = await this.userRepository.findById(followerDto.followId);
     if (!user || !otherUser) {
       throw new BadRequestException('해당하는 사용자의 _id가 올바르지 않습니다.');
@@ -19,29 +19,29 @@ export class UserService {
     if (expectedRelation === RELATION.FOLLOW) {
       // 팔로우 되어있지 않은 경우 팔로우 필요
       this.userRepository.appendElementAtArr(
-        { _id: followerDto.myId },
+        { _id: followerDto.requestUserId },
         { followings: followerDto.followId },
       );
       this.userRepository.appendElementAtArr(
         { _id: followerDto.followId },
-        { followers: followerDto.myId },
+        { followers: followerDto.requestUserId },
       );
       return { message: '팔로우 신청 완료' };
     } else if (expectedRelation === RELATION.UNFOLLOW) {
       // 팔로우 되어있어 언팔로우 필요
       this.userRepository.deleteElementAtArr(
-        { _id: followerDto.myId },
+        { _id: followerDto.requestUserId },
         { followings: [followerDto.followId] },
       );
       this.userRepository.deleteElementAtArr(
         { _id: followerDto.followId },
-        { followers: [followerDto.myId] },
+        { followers: [followerDto.requestUserId] },
       );
       return { message: '언팔로우 완료' };
     }
   }
 
-  async getUser(id: string) {
+  async getUsers(id: string) {
     const users = await this.userRepository.findUser([
       { id: { $regex: id } },
       { nickname: { $regex: id } },
@@ -66,11 +66,11 @@ export class UserService {
   }
 
   async modifyUser(modifyUserDto: ModifyUserDto) {
-    const { _id, ...updateField } = modifyUserDto;
-    const user = await this.userRepository.findById(_id);
+    const { requestUserId, ...updateField } = modifyUserDto;
+    const user = await this.userRepository.findById(requestUserId);
     if (!user) {
       throw new BadRequestException('요청한 사용자는 없는 사용자입니다.');
     }
-    return await this.userRepository.updateOne({ _id }, updateField);
+    return await this.userRepository.updateOne({ _id: requestUserId }, updateField);
   }
 }

--- a/server/apps/api/src/user/user.service.ts
+++ b/server/apps/api/src/user/user.service.ts
@@ -14,6 +14,8 @@ export class UserService {
     const otherUser = await this.userRepository.findById(followerDto.followId);
     if (!user || !otherUser) {
       throw new BadRequestException('해당하는 사용자의 _id가 올바르지 않습니다.');
+    } else if (followerDto.requestUserId === followerDto.followId) {
+      throw new BadRequestException('나 자신은 영원한 인생의 친구입니다.');
     }
     const expectedRelation = checkRelation(user.followings, otherUser.followers, followerDto);
     if (expectedRelation === RELATION.FOLLOW) {

--- a/server/apps/api/src/user/users.controller.ts
+++ b/server/apps/api/src/user/users.controller.ts
@@ -6,8 +6,8 @@ export class UsersController {
   constructor(private userService: UserService) {}
 
   @Get()
-  async getUser(@Query('search') id: string) {
-    const result = await this.userService.getUser(id);
+  async getUsers(@Query('search') id: string) {
+    const result = await this.userService.getUsers(id);
     return { users: result };
   }
 }

--- a/server/custom/interceptor/api.interceptor.ts
+++ b/server/custom/interceptor/api.interceptor.ts
@@ -30,7 +30,7 @@ export class ApiInterceptor implements NestInterceptor {
       catchError((error) => {
         this.logger.error(error.response ?? error);
         if (process.env.NODE_ENV == 'prod') {
-          Sentry.captureException(error);
+          // Sentry.captureException(error);
           const webhook = new IncomingWebhook(process.env.ERROR_SLACK_WEBHOOK);
           webhook.send({
             attachments: [

--- a/server/dao/repository/chat-list.respository.ts
+++ b/server/dao/repository/chat-list.respository.ts
@@ -22,10 +22,7 @@ export class ChatListRespository {
   async findByIdAfterCache(_id: string) {
     const cache = await this.getCache(_id);
     if (cache) {
-      console.log('find by id hit cache ', _id);
       return JSON.parse(cache);
-    } else {
-      console.log('find by id miss cache ', _id);
     }
     return await this.chatListModel.findById(_id);
   }
@@ -67,11 +64,8 @@ export class ChatListRespository {
     const cache = await this.getCache(_id);
     if (!cache) {
       this.findById(_id).then((data) => {
-        console.log('다음 채팅을 찾아 캐시에 저장합니다 ', _id);
         this.storeCache(_id, data);
       });
-    } else {
-      console.log('캐시에 이미 있어 미리저장하지 않습니다. ', _id);
     }
   }
 }

--- a/server/dao/repository/chat-list.respository.ts
+++ b/server/dao/repository/chat-list.respository.ts
@@ -2,10 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { ChatList, ChatListDocument } from '@schemas/chat-list.schema';
 import { Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
+import { InjectRedis } from '@liaoliaots/nestjs-redis';
+import Redis from 'ioredis';
 
 @Injectable()
 export class ChatListRespository {
-  constructor(@InjectModel(ChatList.name) private chatListModel: Model<ChatListDocument>) {}
+  constructor(
+    @InjectModel(ChatList.name) private chatListModel: Model<ChatListDocument>,
+    @InjectRedis() private readonly redis: Redis,
+  ) {}
 
   async create(chat) {
     return await this.chatListModel.create(chat);
@@ -13,17 +18,60 @@ export class ChatListRespository {
   async findById(_id: string) {
     return await this.chatListModel.findById(_id);
   }
+
+  async findByIdAfterCache(_id: string) {
+    const cache = await this.getCache(_id);
+    if (cache) {
+      console.log('find by id hit cache ', _id);
+      return JSON.parse(cache);
+    } else {
+      console.log('find by id miss cache ', _id);
+    }
+    return await this.chatListModel.findById(_id);
+  }
+
   async addArrAtArr(filter, attribute, appendArr) {
+    this.deleteCache(filter._id);
     const addArr = {};
     addArr[attribute] = { $each: appendArr };
     return await this.chatListModel.findByIdAndUpdate(filter, { $addToSet: addArr }, { new: true });
   }
 
   async updateOne(filter, updateField) {
+    this.deleteCache(filter._id);
     return await this.chatListModel.updateOne(filter, updateField);
   }
 
   async findOneAndUpdate(filter, updateField) {
+    this.deleteCache(filter._id);
     return await this.chatListModel.findOneAndUpdate(filter, updateField, { new: true });
+  }
+
+  async deleteCache(_id: string) {
+    if (_id) {
+      this.redis.del(`chats/${_id}`);
+    }
+  }
+
+  async storeCache(_id: string, result: ChatListDocument) {
+    await this.redis.set(`chats/${_id}`, JSON.stringify(result));
+    await this.redis.expire(`chats/${_id}`, 5 * 60);
+  }
+
+  async getCache(_id: string) {
+    return await this.redis.get(`chats/${_id}`);
+  }
+
+  async saveNextExpectedChats(_id: string) {
+    if (_id === undefined) return;
+    const cache = await this.getCache(_id);
+    if (!cache) {
+      this.findById(_id).then((data) => {
+        console.log('다음 채팅을 찾아 캐시에 저장합니다 ', _id);
+        this.storeCache(_id, data);
+      });
+    } else {
+      console.log('캐시에 이미 있어 미리저장하지 않습니다. ', _id);
+    }
   }
 }


### PR DESCRIPTION
## Issues
- #392 

## 🤷‍♂️ Description

- 공간 지역성을 고려한 채팅 저장내용 caching

`@Get /api/channels/:channel_id/chat`
prev, next curser를 전달하며 해당 curser에 대한 내용 사전 저장 (유효기간 5분)

[Minor 수정]
- 자신 follow 불가능하도록 수정
- user dto refactoring
- Merge slack bot 중단

## 📷 Screenshots

18ms -> 8ms 단축

[ 캐싱 전 ]

![image](https://user-images.githubusercontent.com/34162358/210223824-12300519-eb72-43de-aa65-bf113cf10afb.png)

[ 캐싱 후 ]
 

![image](https://user-images.githubusercontent.com/34162358/210224351-7ef2f662-777d-4e4a-8fee-ffa0e68b7a69.png)

