### PR TITLE
[CLIENT] 이전 채팅 불러오는 API 요청이 두 번 발생하는 이슈 해결

### DIFF
--- a/client/src/hooks/useIntersectionObservable.ts
+++ b/client/src/hooks/useIntersectionObservable.ts
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback } from 'react';
 
 /**
  * @param onIntersection 관찰되는 요소가 화면에 보이면 실행되는 콜백 함수
@@ -16,28 +16,22 @@ const useIntersectionObservable = (
 
   const ref = useCallback(
     (node: HTMLElement | null) => {
-      if (!node) return; // 얼리 리턴으로 변경
+      if (!node) return;
 
-      if (!observer.current) {
-        observer.current = new IntersectionObserver((entries, _observer) => {
-          // observer.current === _observer (동일한 값입니다.)
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              onIntersection(entry, _observer);
-            }
-          });
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver((entries, _observer) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            onIntersection(entry, _observer);
+          }
         });
-      }
+      });
 
       observer.current.observe(node);
     },
     [onIntersection], // 이 값이 없으면, onIntersection내부에서 사용되는 isFetching 등의 값이 메모된 값으로 고정됩니다.
   );
-
-  useEffect(() => {
-    // 클린업.
-    return () => observer.current?.disconnect();
-  }, []);
 
   return ref;
 };

--- a/client/src/pages/Channel/index.tsx
+++ b/client/src/pages/Channel/index.tsx
@@ -169,20 +169,21 @@ const Channel = () => {
       </header>
       <div className="flex h-full">
         <div className="flex flex-col relative flex-1 min-w-[768px] max-w-[960px] h-full pb-4">
-          {unreadChatIdQuery.data !== undefined && unreadChatIdQuery.data > -1 && (
-            <div className="flex justify-between items-center w-full h-8 bg-indigo font-medium text-offWhite rounded-b-md text-s14 px-3">
-              <div>위에 읽지 않은 메시지가 있어요</div>
-              <button
-                type="button"
-                className="flex items-center gap-1"
-                onClick={handleMarkAsRead}
-              >
-                <div>읽음으로 표시하기</div>
-                <span className="sr-only">읽음으로 표시하기</span>
-                <CheckCircleIcon className="w-5 h-5" />
-              </button>
-            </div>
-          )}
+          {unreadChatIdQuery.data !== undefined &&
+            unreadChatIdQuery.data > -1 && (
+              <div className="flex justify-between items-center w-full h-8 bg-indigo font-medium text-offWhite rounded-b-md text-s14 px-3">
+                <div>위에 읽지 않은 메시지가 있어요</div>
+                <button
+                  type="button"
+                  className="flex items-center gap-1"
+                  onClick={handleMarkAsRead}
+                >
+                  <div>읽음으로 표시하기</div>
+                  <span className="sr-only">읽음으로 표시하기</span>
+                  <CheckCircleIcon className="w-5 h-5" />
+                </button>
+              </div>
+            )}
           {chatsInfiniteQuery.isFetchingPreviousPage && (
             <div className="flex justify-center items-center font-ipSans text-s14 py-3">
               지난 메시지 불러오는 중


### PR DESCRIPTION
## Issues
- #423 

<!-- 어떤 이슈와 관련된 PR인지 적어주세요! 이슈와 PR을 연결하려면 반드시 적어야 합니다. -->
<!-- 필요하다면 여러 이슈를 적는 것도 가능할지도? -->
<!-- - #IssueNumber 로 타이핑하면 자동완성되는 문장을 사용해주세요. -->
<!-- 예시) - #1 -->

## 🤷‍♂️ Description

사용자가 스크롤을 위로 올리면 이전 채팅을 불러오는 API 요청을 중복하여 두 번 보냄


## 📝 Primary Commits
